### PR TITLE
Resolves JCLOUDS-1261

### DIFF
--- a/apis/s3/src/main/java/org/jclouds/s3/filters/Aws4SignerBase.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/filters/Aws4SignerBase.java
@@ -133,6 +133,22 @@ public abstract class Aws4SignerBase {
       dateFormat.setTimeZone(GMT);
    }
 
+   protected static String hostHeaderFor(URI endpoint) {
+      String scheme = endpoint.getScheme();
+      String host = endpoint.getHost();
+      int port = endpoint.getPort();
+
+      // if the port is defined and doesn't match the URI scheme
+      if (port != -1) {
+         if (("http".equalsIgnoreCase(scheme) && port != 80) ||
+                 ("https".equalsIgnoreCase(scheme) && port != 443)) {
+            host += ":" + port; // append the port number to the hostname
+         }
+      }
+
+      return host; // else just use the original hostname
+   }
+
    protected String getContentType(HttpRequest request) {
       Payload payload = request.getPayload();
 

--- a/apis/s3/src/main/java/org/jclouds/s3/filters/Aws4SignerForAuthorizationHeader.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/filters/Aws4SignerForAuthorizationHeader.java
@@ -75,7 +75,6 @@ public class Aws4SignerForAuthorizationHeader extends Aws4SignerBase {
 
       // get host & port from request endpoint.
       String host = request.getEndpoint().getHost();
-      int port = request.getEndpoint().getPort();
 
       Date date = timestampProvider.get();
       String timestamp = timestampFormat.format(date);
@@ -120,13 +119,7 @@ public class Aws4SignerForAuthorizationHeader extends Aws4SignerBase {
       }
 
       // host
-      // if the port is defined and doesn't match the URI scheme
-      if (port != -1) {
-         if (("http".equalsIgnoreCase(request.getEndpoint().getScheme()) && port != 80) ||
-                 ("https".equalsIgnoreCase(request.getEndpoint().getScheme()) && port != 443)) {
-            host += ":" + port; // append the port number to the hostname
-         }
-      }
+      host = hostHeaderFor(request.getEndpoint());
       requestBuilder.replaceHeader(HttpHeaders.HOST, host);
       signedHeadersBuilder.put(HttpHeaders.HOST.toLowerCase(), host);
 

--- a/apis/s3/src/main/java/org/jclouds/s3/filters/Aws4SignerForAuthorizationHeader.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/filters/Aws4SignerForAuthorizationHeader.java
@@ -73,8 +73,9 @@ public class Aws4SignerForAuthorizationHeader extends Aws4SignerBase {
 
       Payload payload = request.getPayload();
 
-      // get host from request endpoint.
+      // get host & port from request endpoint.
       String host = request.getEndpoint().getHost();
+      int port = request.getEndpoint().getPort();
 
       Date date = timestampProvider.get();
       String timestamp = timestampFormat.format(date);
@@ -119,6 +120,13 @@ public class Aws4SignerForAuthorizationHeader extends Aws4SignerBase {
       }
 
       // host
+      // if the port is defined and doesn't match the URI scheme
+      if (port != -1) {
+         if (("http".equalsIgnoreCase(request.getEndpoint().getScheme()) && port != 80) ||
+                 ("https".equalsIgnoreCase(request.getEndpoint().getScheme()) && port != 443)) {
+            host += ":" + port; // append the port number to the hostname
+         }
+      }
       requestBuilder.replaceHeader(HttpHeaders.HOST, host);
       signedHeadersBuilder.put(HttpHeaders.HOST.toLowerCase(), host);
 

--- a/apis/s3/src/main/java/org/jclouds/s3/filters/Aws4SignerForChunkedUpload.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/filters/Aws4SignerForChunkedUpload.java
@@ -155,6 +155,7 @@ public class Aws4SignerForChunkedUpload extends Aws4SignerBase {
       }
 
       // host
+      host = hostHeaderFor(request.getEndpoint());
       requestBuilder.replaceHeader(HttpHeaders.HOST, host);
       signedHeadersBuilder.put(HttpHeaders.HOST.toLowerCase(), host);
 

--- a/apis/s3/src/main/java/org/jclouds/s3/filters/Aws4SignerForQueryString.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/filters/Aws4SignerForQueryString.java
@@ -102,6 +102,7 @@ public class Aws4SignerForQueryString extends Aws4SignerBase {
       // For added security, you should sign as many headers as possible.
 
       // HOST
+      host = hostHeaderFor(request.getEndpoint());
       signedHeadersBuilder.put("host", host);
       ImmutableMap<String, String> signedHeaders = signedHeadersBuilder.build();
 


### PR DESCRIPTION
Ensures non-standard port numbers are in the host header that's used for the AWSv4 auth calculations.