### PR TITLE
JCLOUDS-1495: maven plugins are not correctly referred to

### DIFF
--- a/apis/openstack-keystone/pom.xml
+++ b/apis/openstack-keystone/pom.xml
@@ -108,6 +108,7 @@
     <!-- Disabling error-prone compiler due to: https://github.com/google/error-prone/issues/711
          The fix is only available in error-prone versions that do not support Java 7 -->
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <inherited>false</inherited>
         <configuration>

--- a/project/pom.xml
+++ b/project/pom.xml
@@ -652,6 +652,7 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${surefire.version}</version>
         <executions>
@@ -703,6 +704,7 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>1.1.1</version>
         <executions>
@@ -740,6 +742,7 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>
@@ -889,6 +892,7 @@
         </dependencies>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
         <version>2.6</version>
         <configuration>


### PR DESCRIPTION
Some maven plugins are not properly addressed.