### PR TITLE
JCLOUDS-1499: Disable sonatype snapshot repository for plugins

### DIFF
--- a/project/pom.xml
+++ b/project/pom.xml
@@ -110,13 +110,6 @@
         <enabled>true</enabled>
       </snapshots>
     </pluginRepository>
-    <pluginRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </pluginRepository>
   </pluginRepositories>
 
   <distributionManagement>


### PR DESCRIPTION
As far as I can see, the ossrh repository (https://oss.sonatype.org/content/repositories/snapshots)
is not needed.
It slows down compilation considerably.
Lets remove the maven repository from the pom