### PR TITLE
JCLOUDS-1500: Update gson to 2.8.5

### DIFF
--- a/core/src/main/java/org/jclouds/json/internal/DeserializationConstructorAndReflectiveTypeAdapterFactory.java
+++ b/core/src/main/java/org/jclouds/json/internal/DeserializationConstructorAndReflectiveTypeAdapterFactory.java
@@ -26,6 +26,7 @@ import java.lang.reflect.Modifier;
 import java.util.List;
 import java.util.Map;
 
+import org.jclouds.json.gson.internal.bind.JsonAdapterAnnotationTypeAdapterFactory;
 import org.jclouds.json.gson.internal.ConstructorConstructor;
 import org.jclouds.json.gson.internal.Excluder;
 import org.jclouds.json.gson.internal.bind.ReflectiveTypeAdapterFactory;
@@ -115,7 +116,8 @@ public final class DeserializationConstructorAndReflectiveTypeAdapterFactory imp
       this.constructorFieldNamingPolicy = checkNotNull(deserializationFieldNamingPolicy,
             "deserializationFieldNamingPolicy");
       this.delegateFactory = new ReflectiveTypeAdapterFactory(constructorConstructor, checkNotNull(
-            serializationFieldNamingPolicy, "fieldNamingPolicy"), checkNotNull(excluder, "excluder"));
+            serializationFieldNamingPolicy, "fieldNamingPolicy"), checkNotNull(excluder, "excluder"),
+              new JsonAdapterAnnotationTypeAdapterFactory(constructorConstructor));
    }
 
    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {

--- a/gson/gson-shaded/pom.xml
+++ b/gson/gson-shaded/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.5</version>
+      <version>2.8.5</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
If we do not have to consider to fix JCLOUDS-1166 in the first place (using of internal gson API) , updating gson is a piece of cake