### PR TITLE
Checks provisioning state in Rule resource instead of Group

### DIFF
--- a/providers/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/extensions/AzureComputeSecurityGroupExtension.java
+++ b/providers/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/extensions/AzureComputeSecurityGroupExtension.java
@@ -294,11 +294,11 @@ public class AzureComputeSecurityGroupExtension implements SecurityGroupExtensio
 
       for (NetworkSecurityRule matchingRule : rules) {
          logger.debug(">> deleting network security rule %s from %s...", matchingRule.name(), group.getName());
-         ruleApi.delete(matchingRule.name());
-         URI uri = api.getNetworkSecurityRuleApi(resourceGroupAndName.resourceGroup(), networkSecurityGroup.name()).delete(resourceGroupAndName.name());
+         URI uri = ruleApi.delete(matchingRule.name());
          if (uri != null) {
-            resourceDeleted.apply(uri);
+            checkState(resourceDeleted.apply(uri), "Rule %s could not be deleted", matchingRule.id());
          }
+
       }
 
       return getSecurityGroupById(group.getId());

--- a/providers/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/extensions/AzureComputeSecurityGroupExtension.java
+++ b/providers/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/compute/extensions/AzureComputeSecurityGroupExtension.java
@@ -296,7 +296,7 @@ public class AzureComputeSecurityGroupExtension implements SecurityGroupExtensio
          logger.debug(">> deleting network security rule %s from %s...", matchingRule.name(), group.getName());
          URI uri = ruleApi.delete(matchingRule.name());
          if (uri != null) {
-            checkState(resourceDeleted.apply(uri), "Rule %s could not be deleted", matchingRule.id());
+            checkState(resourceDeleted.apply(uri), "Rule %s could not be deleted in the configured timeout", matchingRule.id());
          }
 
       }

--- a/providers/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/domain/NetworkSecurityRuleProperties.java
+++ b/providers/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/domain/NetworkSecurityRuleProperties.java
@@ -16,14 +16,14 @@
  */
 package org.jclouds.azurecompute.arm.domain;
 
-import com.google.auto.value.AutoValue;
-
 import org.jclouds.azurecompute.arm.util.GetEnumValue;
 import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.json.SerializedNames;
 
+import com.google.auto.value.AutoValue;
+
 @AutoValue
-public abstract class NetworkSecurityRuleProperties {
+public abstract class NetworkSecurityRuleProperties implements Provisionable {
    public enum Protocol {
       // * is an allowed value, will handle in
       Tcp("Tcp"),
@@ -91,7 +91,10 @@ public abstract class NetworkSecurityRuleProperties {
 
    public abstract Direction direction();
 
-   @SerializedNames({"description", "protocol", "sourcePortRange", "destinationPortRange", "sourceAddressPrefix", "destinationAddressPrefix", "access", "priority", "direction"})
+   @Nullable
+   public abstract String provisioningState();
+
+   @SerializedNames({ "description", "protocol", "sourcePortRange", "destinationPortRange", "sourceAddressPrefix", "destinationAddressPrefix", "access", "priority", "direction", "provisioningState" })
    public static NetworkSecurityRuleProperties create(final String description,
                                                       final Protocol protocol,
                                                       final String sourcePortRange,
@@ -100,7 +103,8 @@ public abstract class NetworkSecurityRuleProperties {
                                                       final String destinationAddressPrefix,
                                                       final Access access,
                                                       final Integer priority,
-                                                      final Direction direction) {
+                                                      final Direction direction,
+                                                      final String provisioningState) {
       return builder()
               .description(description)
               .protocol(protocol)
@@ -110,7 +114,7 @@ public abstract class NetworkSecurityRuleProperties {
               .destinationAddressPrefix(destinationAddressPrefix)
               .access(access)
               .priority(priority)
-              .direction(direction)
+              .direction(direction).provisioningState(provisioningState)
               .build();
    }
    
@@ -139,6 +143,8 @@ public abstract class NetworkSecurityRuleProperties {
       public abstract Builder priority(Integer priority);
 
       public abstract Builder direction(Direction direction);
+
+      public abstract Builder provisioningState(String provisioningState);
 
       public abstract NetworkSecurityRuleProperties build();
    }

--- a/providers/azurecompute-arm/src/test/java/org/jclouds/azurecompute/arm/features/NetworkSecurityGroupApiMockTest.java
+++ b/providers/azurecompute-arm/src/test/java/org/jclouds/azurecompute/arm/features/NetworkSecurityGroupApiMockTest.java
@@ -54,6 +54,7 @@ public class NetworkSecurityGroupApiMockTest extends BaseAzureComputeApiMockTest
                       .access(NetworkSecurityRuleProperties.Access.Deny)
                       .priority(4095)
                       .direction(NetworkSecurityRuleProperties.Direction.Outbound)
+                      .provisioningState("Succeeded")
                       .build());
       ArrayList<NetworkSecurityRule> ruleList = new ArrayList<NetworkSecurityRule>();
       ruleList.add(rule);

--- a/providers/azurecompute-arm/src/test/java/org/jclouds/azurecompute/arm/features/NetworkSecurityRuleApiMockTest.java
+++ b/providers/azurecompute-arm/src/test/java/org/jclouds/azurecompute/arm/features/NetworkSecurityRuleApiMockTest.java
@@ -52,6 +52,7 @@ public class NetworkSecurityRuleApiMockTest extends BaseAzureComputeApiMockTest 
                       .access(NetworkSecurityRuleProperties.Access.Allow)
                       .priority(4094)
                       .direction(NetworkSecurityRuleProperties.Direction.Inbound)
+                      .provisioningState("Succeeded")
                       .build());
       return rule;
    }

--- a/providers/azurecompute-arm/src/test/resources/networksecurityrulecreate.json
+++ b/providers/azurecompute-arm/src/test/resources/networksecurityrulecreate.json
@@ -12,6 +12,7 @@
     "destinationAddressPrefix": "*",
     "access": "Allow",
     "priority": 4094,
-    "direction": "Inbound"
+    "direction": "Inbound",
+    "provisioningState": "Succeeded"
   }
 }


### PR DESCRIPTION
* We were checking the provisioningState security group resource. When updating rules concurrently this check returns OK (the security group is ok) but the actual rules are still being updated (created/deleted) causing random problems.

* PR implements provisioningState in `NetworkSecurityRuleProperties` to do this check properly (https://docs.microsoft.com/en-us/rest/api/virtualnetwork/securityrules/get#securityrule)
