### PR TITLE
JCLOUDS-1428 - Support for SAS token based Authentication for Azure Blob Storage

### DIFF
--- a/providers/azureblob/src/main/java/org/jclouds/azureblob/blobstore/functions/BlobPropertiesToBlobMetadata.java
+++ b/providers/azureblob/src/main/java/org/jclouds/azureblob/blobstore/functions/BlobPropertiesToBlobMetadata.java
@@ -28,10 +28,13 @@ import org.jclouds.blobstore.domain.MutableBlobMetadata;
 import org.jclouds.blobstore.domain.StorageType;
 import org.jclouds.blobstore.domain.internal.MutableBlobMetadataImpl;
 import org.jclouds.http.HttpUtils;
+import org.jclouds.azureblob.config.InsufficientAccessRightsException;
+import org.jclouds.util.Throwables2;
 
 import com.google.common.base.Function;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+
 
 @Singleton
 public class BlobPropertiesToBlobMetadata implements Function<BlobProperties, MutableBlobMetadata> {
@@ -58,8 +61,10 @@ public class BlobPropertiesToBlobMetadata implements Function<BlobProperties, Mu
             PublicAccess containerAcl = containerAcls.getUnchecked(from.getContainer());
             if (containerAcl != PublicAccess.PRIVATE)
                to.setPublicUri(from.getUrl());
-         } catch (CacheLoader.InvalidCacheLoadException e) {
-            // nulls not permitted from cache loader
+         } catch (Exception ex) {
+            //AzureBlob is not a publicly accessible object, but it is impossible to obtain ACL using SAS Auth. 
+            InsufficientAccessRightsException iare = Throwables2.getFirstThrowableOfType(ex, InsufficientAccessRightsException.class);
+            if (iare == null) throw ex;  
          }
       if (to.getContentMetadata() != null && to.getContentMetadata().getContentType() != null &&
             to.getContentMetadata().getContentType().equals("application/directory")) {

--- a/providers/azureblob/src/main/java/org/jclouds/azureblob/blobstore/functions/BlobPropertiesToBlobMetadata.java
+++ b/providers/azureblob/src/main/java/org/jclouds/azureblob/blobstore/functions/BlobPropertiesToBlobMetadata.java
@@ -32,7 +32,6 @@ import org.jclouds.azureblob.config.InsufficientAccessRightsException;
 import org.jclouds.util.Throwables2;
 
 import com.google.common.base.Function;
-import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 
 

--- a/providers/azureblob/src/main/java/org/jclouds/azureblob/config/InsufficientAccessRightsException.java
+++ b/providers/azureblob/src/main/java/org/jclouds/azureblob/config/InsufficientAccessRightsException.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+ 
+/**
+ * Handles the inability of SAS Authentication string to authenticate the getAcl and setAcl requests.
+ * 
+ */
+ 
+package org.jclouds.azureblob.config;
+
+public class InsufficientAccessRightsException extends RuntimeException {
+
+   public InsufficientAccessRightsException(String message) {
+      super(message);
+   }
+
+}


### PR DESCRIPTION
Removed the ACL check for the AzureBlobs, authorised with SAS Auth String. 
Implemented all change requests from the previous PR #23. 