### PR TITLE
Fix regression in azureblob and properly catch unchecked exceptions

### DIFF
--- a/providers/azureblob/src/main/java/org/jclouds/azureblob/blobstore/functions/BlobPropertiesToBlobMetadata.java
+++ b/providers/azureblob/src/main/java/org/jclouds/azureblob/blobstore/functions/BlobPropertiesToBlobMetadata.java
@@ -60,7 +60,7 @@ public class BlobPropertiesToBlobMetadata implements Function<BlobProperties, Mu
             PublicAccess containerAcl = containerAcls.getUnchecked(from.getContainer());
             if (containerAcl != PublicAccess.PRIVATE)
                to.setPublicUri(from.getUrl());
-         } catch (Exception ex) {
+         } catch (RuntimeException ex) {
             //AzureBlob is not a publicly accessible object, but it is impossible to obtain ACL using SAS Auth. 
             InsufficientAccessRightsException iare = Throwables2.getFirstThrowableOfType(ex, InsufficientAccessRightsException.class);
             if (iare == null) throw ex;  


### PR DESCRIPTION
Fix a regression introduced in https://github.com/apache/jclouds/pull/34

The method implements `Function` and cannot declare an exception to be thrown, so we should only propagate RuntimeExceptions.
It is fine to just catch that since the methods inside the catch block are not meant to throw checked exceptions.

/cc @ak58588 