### PR TITLE
JCLOUDS-1511: allow configuration of S3 to use V4 signatures

### DIFF
--- a/apis/s3/src/main/java/org/jclouds/s3/S3ApiMetadata.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/S3ApiMetadata.java
@@ -18,7 +18,6 @@ package org.jclouds.s3;
 
 import static org.jclouds.Constants.PROPERTY_IDEMPOTENT_METHODS;
 import static org.jclouds.Constants.PROPERTY_RELAX_HOSTNAME;
-import static org.jclouds.Constants.PROPERTY_V4_REQUEST_SIGNATURES;
 import static org.jclouds.aws.reference.AWSConstants.PROPERTY_AUTH_TAG;
 import static org.jclouds.aws.reference.AWSConstants.PROPERTY_HEADER_TAG;
 import static org.jclouds.blobstore.reference.BlobStoreConstants.PROPERTY_BLOBSTORE_DIRECTORY_SUFFIX;
@@ -26,6 +25,7 @@ import static org.jclouds.blobstore.reference.BlobStoreConstants.PROPERTY_USER_M
 import static org.jclouds.reflect.Reflection2.typeToken;
 import static org.jclouds.s3.reference.S3Constants.PROPERTY_JCLOUDS_S3_CHUNKED_SIZE;
 import static org.jclouds.s3.reference.S3Constants.PROPERTY_S3_SERVICE_PATH;
+import static org.jclouds.s3.reference.S3Constants.PROPERTY_S3_V4_REQUEST_SIGNATURES;
 import static org.jclouds.s3.reference.S3Constants.PROPERTY_S3_VIRTUAL_HOST_BUCKETS;
 
 import java.net.URI;
@@ -80,7 +80,7 @@ public class S3ApiMetadata extends BaseHttpApiMetadata {
       properties.setProperty(PROPERTY_S3_VIRTUAL_HOST_BUCKETS, "false");
       properties.setProperty(PROPERTY_RELAX_HOSTNAME, "true");
       properties.setProperty(PROPERTY_BLOBSTORE_DIRECTORY_SUFFIX, "/");
-      properties.setProperty(PROPERTY_V4_REQUEST_SIGNATURES, "false");
+      properties.setProperty(PROPERTY_S3_V4_REQUEST_SIGNATURES, "false");
       properties.setProperty(PROPERTY_USER_METADATA_PREFIX, String.format("x-${%s}-meta-", PROPERTY_HEADER_TAG));
       properties.setProperty(PROPERTY_IDEMPOTENT_METHODS, "DELETE,GET,HEAD,OPTIONS,POST,PUT");
 

--- a/apis/s3/src/main/java/org/jclouds/s3/S3ApiMetadata.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/S3ApiMetadata.java
@@ -18,6 +18,7 @@ package org.jclouds.s3;
 
 import static org.jclouds.Constants.PROPERTY_IDEMPOTENT_METHODS;
 import static org.jclouds.Constants.PROPERTY_RELAX_HOSTNAME;
+import static org.jclouds.Constants.PROPERTY_V4_REQUEST_SIGNATURES;
 import static org.jclouds.aws.reference.AWSConstants.PROPERTY_AUTH_TAG;
 import static org.jclouds.aws.reference.AWSConstants.PROPERTY_HEADER_TAG;
 import static org.jclouds.blobstore.reference.BlobStoreConstants.PROPERTY_BLOBSTORE_DIRECTORY_SUFFIX;
@@ -79,6 +80,7 @@ public class S3ApiMetadata extends BaseHttpApiMetadata {
       properties.setProperty(PROPERTY_S3_VIRTUAL_HOST_BUCKETS, "false");
       properties.setProperty(PROPERTY_RELAX_HOSTNAME, "true");
       properties.setProperty(PROPERTY_BLOBSTORE_DIRECTORY_SUFFIX, "/");
+      properties.setProperty(PROPERTY_V4_REQUEST_SIGNATURES, "false");
       properties.setProperty(PROPERTY_USER_METADATA_PREFIX, String.format("x-${%s}-meta-", PROPERTY_HEADER_TAG));
       properties.setProperty(PROPERTY_IDEMPOTENT_METHODS, "DELETE,GET,HEAD,OPTIONS,POST,PUT");
 

--- a/apis/s3/src/main/java/org/jclouds/s3/config/S3HttpApiModule.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/config/S3HttpApiModule.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import com.google.inject.Injector;
 import org.jclouds.Constants;
 import org.jclouds.aws.config.AWSHttpApiModule;
 import org.jclouds.aws.handlers.AWSClientErrorRetryHandler;
@@ -53,6 +54,7 @@ import org.jclouds.s3.filters.RequestAuthorizeSignatureV4;
 import org.jclouds.s3.functions.GetRegionForBucket;
 import org.jclouds.s3.handlers.ParseS3ErrorFromXmlContent;
 import org.jclouds.s3.handlers.S3RedirectionRetryHandler;
+import org.jclouds.s3.reference.S3Constants;
 
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
@@ -63,7 +65,6 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Iterables;
 import com.google.inject.Provides;
-import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
 
 /**
@@ -185,14 +186,9 @@ public class S3HttpApiModule<S extends S3Client> extends AWSHttpApiModule<S> {
 
    @Provides
    @Singleton
-   protected void bindRequestSigner(@Named(Constants.PROPERTY_V4_REQUEST_SIGNATURES) boolean v4Signatures) {
-      Class<? extends RequestAuthorizeSignature> clazz;
-      if (v4Signatures) {
-         clazz = RequestAuthorizeSignatureV4.class;
-      } else {
-         clazz = RequestAuthorizeSignatureV2.class;
-      }
-      bind(RequestAuthorizeSignature.class).to(clazz).in(Scopes.SINGLETON);
+   protected RequestAuthorizeSignature bindRequestSigner(
+           @Named(S3Constants.PROPERTY_S3_V4_REQUEST_SIGNATURES) boolean v4Signatures, Injector injector) {
+      return injector.getInstance(v4Signatures ? RequestAuthorizeSignatureV4.class : RequestAuthorizeSignatureV2.class);
    }
 
    @Provides

--- a/apis/s3/src/main/java/org/jclouds/s3/reference/S3Constants.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/reference/S3Constants.java
@@ -33,6 +33,13 @@ public final class S3Constants {
    public static final String PROPERTY_S3_VIRTUAL_HOST_BUCKETS = "jclouds.s3.virtual-host-buckets";
    public static final String PROPERTY_JCLOUDS_S3_CHUNKED_SIZE = "jclouds.s3.chunked.size";
 
+   /**
+    * Boolean property. Default (false).
+    * <p/>
+    * Enables the use of V4 request signatures.
+    */
+   public static final String PROPERTY_S3_V4_REQUEST_SIGNATURES = "jclouds.s3.v4signatures";
+
    public static final String TEMPORARY_SIGNATURE_PARAM = "Signature";
 
    private S3Constants() {

--- a/apis/s3/src/test/java/org/jclouds/s3/config/S3HttpApiModuleTest.java
+++ b/apis/s3/src/test/java/org/jclouds/s3/config/S3HttpApiModuleTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jclouds.s3.config;
 
 import com.google.common.collect.ImmutableList;
@@ -25,9 +41,6 @@ import static org.jclouds.Constants.PROPERTY_SESSION_INTERVAL;
 import static org.jclouds.s3.reference.S3Constants.PROPERTY_S3_V4_REQUEST_SIGNATURES;
 import static org.testng.Assert.assertTrue;
 
-/**
- * @author roded
- */
 public class S3HttpApiModuleTest {
 
     @Test

--- a/apis/s3/src/test/java/org/jclouds/s3/config/S3HttpApiModuleTest.java
+++ b/apis/s3/src/test/java/org/jclouds/s3/config/S3HttpApiModuleTest.java
@@ -1,0 +1,63 @@
+package org.jclouds.s3.config;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.ByteSource;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Module;
+import com.google.inject.name.Names;
+import org.jclouds.location.config.LocationModule;
+import org.jclouds.logging.config.NullLoggingModule;
+import org.jclouds.providers.JcloudsTestBlobStoreProviderMetadata;
+import org.jclouds.providers.ProviderMetadata;
+import org.jclouds.rest.config.CredentialStoreModule;
+import org.jclouds.rest.internal.BaseRestApiTest;
+import org.jclouds.s3.blobstore.config.S3BlobStoreContextModule;
+import org.jclouds.s3.filters.RequestAuthorizeSignature;
+import org.jclouds.s3.filters.RequestAuthorizeSignatureV2;
+import org.jclouds.s3.filters.RequestAuthorizeSignatureV4;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.jclouds.Constants.PROPERTY_SESSION_INTERVAL;
+import static org.jclouds.s3.reference.S3Constants.PROPERTY_S3_V4_REQUEST_SIGNATURES;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * @author roded
+ */
+public class S3HttpApiModuleTest {
+
+    @Test
+    public void testRequestAuthorizeSignatureV2() {
+        RequestAuthorizeSignature requestAuthorizeSignature = getRequestAuthorizeSignature("false");
+        assertTrue(requestAuthorizeSignature instanceof RequestAuthorizeSignatureV2);
+    }
+
+    @Test
+    public void testRequestAuthorizeSignatureV4() {
+        RequestAuthorizeSignature requestAuthorizeSignature = getRequestAuthorizeSignature("true");
+        assertTrue(requestAuthorizeSignature instanceof RequestAuthorizeSignatureV4);
+    }
+
+    private RequestAuthorizeSignature getRequestAuthorizeSignature(final String s3V4Value) {
+        AbstractModule abstractModule = new AbstractModule() {
+            @Override
+            protected void configure() {
+                bindConstant().annotatedWith(Names.named(PROPERTY_S3_V4_REQUEST_SIGNATURES)).to(s3V4Value);
+                bind(String.class).annotatedWith(Names.named(PROPERTY_SESSION_INTERVAL)).toInstance("60");
+                bind(ProviderMetadata.class).to(JcloudsTestBlobStoreProviderMetadata.class);
+            }
+        };
+        List<Module> modules = ImmutableList.<Module>of(new BaseRestApiTest.MockModule(),
+                new CredentialStoreModule(new ConcurrentHashMap<String, ByteSource>()),
+                new S3BlobStoreContextModule(),
+                new NullLoggingModule(),
+                new S3HttpApiModule<>(),
+                new LocationModule(),
+                abstractModule);
+        return Guice.createInjector(modules).getInstance(RequestAuthorizeSignature.class);
+    }
+}

--- a/core/src/main/java/org/jclouds/Constants.java
+++ b/core/src/main/java/org/jclouds/Constants.java
@@ -355,6 +355,13 @@ public final class Constants {
    public static final String PROPERTY_USER_AGENT = "jclouds.user-agent";
 
    /**
+    * Boolean property. Default (false).
+    * <p/>
+    * Enables the use of V4 request signatures.
+    */
+   public static final String PROPERTY_V4_REQUEST_SIGNATURES = "jclouds.v4signatures";
+
+   /**
     * When true, add the Connection: close header. Useful when interacting with
     * providers that don't properly support persistent connections. Defaults to false.
     */

--- a/core/src/main/java/org/jclouds/Constants.java
+++ b/core/src/main/java/org/jclouds/Constants.java
@@ -355,13 +355,6 @@ public final class Constants {
    public static final String PROPERTY_USER_AGENT = "jclouds.user-agent";
 
    /**
-    * Boolean property. Default (false).
-    * <p/>
-    * Enables the use of V4 request signatures.
-    */
-   public static final String PROPERTY_V4_REQUEST_SIGNATURES = "jclouds.v4signatures";
-
-   /**
     * When true, add the Connection: close header. Useful when interacting with
     * providers that don't properly support persistent connections. Defaults to false.
     */

--- a/providers/aws-s3/src/main/java/org/jclouds/aws/s3/AWSS3ApiMetadata.java
+++ b/providers/aws-s3/src/main/java/org/jclouds/aws/s3/AWSS3ApiMetadata.java
@@ -17,6 +17,7 @@
 package org.jclouds.aws.s3;
 
 import static org.jclouds.reflect.Reflection2.typeToken;
+import static org.jclouds.s3.reference.S3Constants.PROPERTY_S3_V4_REQUEST_SIGNATURES;
 import static org.jclouds.s3.reference.S3Constants.PROPERTY_S3_VIRTUAL_HOST_BUCKETS;
 
 import java.util.Properties;
@@ -50,6 +51,7 @@ public class AWSS3ApiMetadata extends S3ApiMetadata {
    public static Properties defaultProperties() {
       Properties properties = S3ApiMetadata.defaultProperties();
       properties.setProperty(PROPERTY_S3_VIRTUAL_HOST_BUCKETS, "true");
+      properties.setProperty(PROPERTY_S3_V4_REQUEST_SIGNATURES, "true");
       return properties;
    }
 


### PR DESCRIPTION
Added the "jclouds.v4signatures" property to allow configuring S3 to
use V4 signatures instead of the default V2.

This is a draft. Comments are more than welcome (possible issues: property name, logic in a Guice module). Specifically, I'm not sure where testing of this functionality should go - if there's an example to follow it would be helpful.