### PR TITLE
JCLOUDS-1520: change UntrustedSSLContextSupplier to return the same S…

### DIFF
--- a/core/src/main/java/org/jclouds/http/config/SSLModule.java
+++ b/core/src/main/java/org/jclouds/http/config/SSLModule.java
@@ -74,24 +74,22 @@ public class SSLModule extends AbstractModule {
 
    @Singleton
    public static class UntrustedSSLContextSupplier implements Supplier<SSLContext> {
-      private final TrustAllCerts trustAllCerts;
+      private final SSLContext sslContext;
 
       @Inject
       UntrustedSSLContextSupplier(TrustAllCerts trustAllCerts) {
-         this.trustAllCerts = trustAllCerts;
+         try {
+            SSLContext sslContext = SSLContext.getInstance("SSL");
+            sslContext.init(null, new TrustManager[] { trustAllCerts }, new SecureRandom());
+            this.sslContext = sslContext;
+         } catch (Exception e) {
+            throw Throwables.propagate(e);
+         }
       }
 
       @Override
       public SSLContext get() {
-         try {
-            SSLContext sc;
-            sc = SSLContext.getInstance("SSL");
-            sc.init(null, new TrustManager[] { trustAllCerts }, new SecureRandom());
-            return sc;
-         } catch (Exception e) {
-            throw Throwables.propagate(e);
-         }
-
+         return sslContext;
       }
    }
 

--- a/core/src/test/java/org/jclouds/http/config/SSLModuleTest.java
+++ b/core/src/test/java/org/jclouds/http/config/SSLModuleTest.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.http.config;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertSame;
+
+@Test(testName = "http.config.SSLModuleTest")
+public class SSLModuleTest {
+
+    @Test
+    public void sameUntrustedSslContext() {
+        Injector injector = Guice.createInjector(new SSLModule());
+        SSLModule.UntrustedSSLContextSupplier untrustedSSLContextSupplier = injector.getInstance(SSLModule.UntrustedSSLContextSupplier.class);
+        assertSame(untrustedSSLContextSupplier.get(), untrustedSSLContextSupplier.get());
+    }
+}


### PR DESCRIPTION
…SLContext

Using the same SSLContext prevents consistent cache misses on the JVM's KeepAliveCache
when attempting to reuse TLS connections.