### PR TITLE
Add TravisCI file for pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: java
 
 env:
-  - LC_ALL=en_US.UTF-8
-  - LANG=en_US.UTF-8
+  - LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
 
 jdk:
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,5 @@ cache:
   directories:
     - $HOME/.m2
 
-script: mvn clean verify checkstyle:checkstyle -e -Dmaven.javadoc.skip=true
+script: mvn clean verify checkstyle:checkstyle -B -q -Dmaven.javadoc.skip=true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ env:
   - LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
 
 jdk:
-  - oraclejdk8
   - openjdk8
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,11 @@ jdk:
   - openjdk8
 
 sudo: false
+install: skip
 
 cache:
   directories:
     - $HOME/.m2
 
-script: mvn clean verify checkstyle:checkstyle -B -q -Dmaven.javadoc.skip=true
+script: mvn clean verify checkstyle:checkstyle -B -q -Dmaven.javadoc.skip=true -Dorg.slf4j.simpleLogger.defaultLogLevel=ERROR 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,5 @@ cache:
   directories:
     - $HOME/.m2
 
-script: mvn clean verify checkstyle:checkstyle -e -Dmaven.javadoc.skip=true -Pjenkins
+script: mvn clean verify checkstyle:checkstyle -e -Dmaven.javadoc.skip=true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 language: java
 
 env:
@@ -5,6 +20,8 @@ env:
 
 jdk:
   - openjdk8
+
+sudo: false
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: java
+
+env:
+  - LC_ALL=en_US.UTF-8
+  - LANG=en_US.UTF-8
+
+jdk:
+  - oraclejdk8
+  - openjdk8
+
+cache:
+  directories:
+    - $HOME/.m2
+
+script: mvn clean verify checkstyle:checkstyle -e -Dmaven.javadoc.skip=true -Pjenkins
+


### PR DESCRIPTION
ASF Jenkins PR builds are only enabled for PRs made by committers and PMC members. To have PR builds on all contributions, we requested that TracisCI was enabled in the repos.
This PR adds a basic config file so Travis builds are triggered on PRs.