### PR TITLE
Fix infinite socket timeout when using ApacheHCHttpCommandExecutorServiceModule

### DIFF
--- a/drivers/apachehc/src/main/java/org/jclouds/http/apachehc/config/ApacheHCHttpCommandExecutorServiceModule.java
+++ b/drivers/apachehc/src/main/java/org/jclouds/http/apachehc/config/ApacheHCHttpCommandExecutorServiceModule.java
@@ -143,7 +143,7 @@ public class ApacheHCHttpCommandExecutorServiceModule extends AbstractModule {
 
    @Provides
    @Singleton
-   final HttpClient newDefaultHttpClient(ProxyConfig config, BasicHttpParams params, ClientConnectionManager cm) {
+   final HttpClient newDefaultHttpClient(ProxyConfig config, HttpParams params, ClientConnectionManager cm) {
       DefaultHttpClient client = new DefaultHttpClient(cm, params);
       if (config.useSystem()) {
          ProxySelectorRoutePlanner routePlanner = new ProxySelectorRoutePlanner(client.getConnectionManager()


### PR DESCRIPTION
Because the Java type BasicHttpParams wasn't matching the one returned
by provider "newBasicHttpParams" (which is returning a HttpParams type), it was configuring the Apache HTTP client with default settings (including connection and socket timeout), ignoring the ones of JClouds which were must safer in this regard (JCloudsones are currently 60sec for both, while Apache HC ones are -1, so infinite). It also prevented to override those default/infinite timeout settings with JClouds ones.