### PR TITLE
Downgrade BouncyCastle to 1.60, which works with Oracle JDK 1.7

### DIFF
--- a/drivers/bouncycastle/pom.xml
+++ b/drivers/bouncycastle/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-ext-jdk15on</artifactId>
-      <version>1.64</version>
+      <version>1.60</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
This version fixes the CVEs, yet also works with Oracle JDK 1.7.

@nacx 