### PR TITLE
JCLOUDS-1529: Do not export org.jclouds.json.gson.internal because it causes a

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -39,7 +39,11 @@
 
   <properties>
     <jclouds.osgi.import>*</jclouds.osgi.import>
-    <jclouds.osgi.export>org.jclouds*;version=${project.version};-noimport:=true</jclouds.osgi.export>
+    <!-- https://issues.apache.org/jira/browse/JCLOUDS-1529 -->
+    <jclouds.osgi.export>
+      !org.jclouds.json.gson.internal*,
+      org.jclouds*;version=${project.version};-noimport:=true
+    </jclouds.osgi.export>
     <jclouds.osgi.activator>org.jclouds.osgi.Activator</jclouds.osgi.activator>
   </properties>
 


### PR DESCRIPTION
use constraint violation with OSGi.

https://issues.apache.org/jira/browse/JCLOUDS-1529