### PR TITLE
Fix BlobMetadata null size when using ApacheHCHttpCommandExecutorServ…

### DIFF
--- a/drivers/apachehc/src/main/java/org/jclouds/http/apachehc/ApacheHCHttpCommandExecutorService.java
+++ b/drivers/apachehc/src/main/java/org/jclouds/http/apachehc/ApacheHCHttpCommandExecutorService.java
@@ -103,11 +103,13 @@ public class ApacheHCHttpCommandExecutorService extends BaseHttpCommandExecutorS
       Multimap<String, String> headers = LinkedHashMultimap.create();
       for (Header header : apacheResponse.getAllHeaders()) {
          headers.put(header.getName(), header.getValue());
+      } else {
+         // still create a payload object on no entity responses (ex: to HEAD requests) as this is apparently where JClouds is
+         // exclusively looking for the content metadata (in order to fill in the BlobMetadata with correct size) 
+         payload = Payloads.newStringPayload("");
       }
-      if (payload != null) {
-         contentMetadataCodec.fromHeaders(payload.getContentMetadata(), headers);
-         headers = filterOutContentHeaders(headers);
-      }
+      contentMetadataCodec.fromHeaders(payload.getContentMetadata(), headers);
+      headers = filterOutContentHeaders(headers);
       return HttpResponse.builder().statusCode(apacheResponse.getStatusLine().getStatusCode())
                                    .message(apacheResponse.getStatusLine().getReasonPhrase())
                                    .payload(payload)


### PR DESCRIPTION
…iceModule

JClouds is apparently exclusively using the Payload object from the HTTP
response to fill in the size of the BlobMetadata (when calling
blobStore.blobMetadata(...) ) - adapt this driver accordingly otherwise
we systematically get null size BlobMetadata out of it.