### PR TITLE
Fix javadoc generation on JDK >= 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,9 @@
         <plugins>
           <plugin>
             <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+              <additionalparam>${javadoc.opts}</additionalparam>
+            </configuration>
             <executions>
               <execution>
                 <id>javadoc</id>

--- a/project/pom.xml
+++ b/project/pom.xml
@@ -886,6 +886,7 @@
                   <encoding>${project.build.sourceEncoding}</encoding>
                   <quiet>true</quiet>
                   <maxmemory>512m</maxmemory>
+                  <additionalparam>${javadoc.opts}</additionalparam>
                 </configuration>
                 <reportSets>
                   <reportSet>
@@ -987,6 +988,7 @@
             <maxmemory>512m</maxmemory>
             <encoding>${project.build.sourceEncoding}</encoding>
             <quiet>true</quiet>
+            <additionalparam>${javadoc.opts}</additionalparam>
             <links>
               <link>https://download.oracle.com/javase/6/docs/api/</link>
             </links>
@@ -1209,6 +1211,15 @@
   </reporting>
   <profiles>
     <profile>
+      <id>disable-doclint</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <properties>
+        <javadoc.opts>-Xdoclint:none</javadoc.opts>
+      </properties>
+    </profile>
+    <profile>
       <id>live</id>
       <build>
         <plugins>
@@ -1421,6 +1432,9 @@
           <plugin>
             <artifactId>maven-javadoc-plugin</artifactId>
             <version>2.9</version>
+            <configuration>
+              <additionalparam>${javadoc.opts}</additionalparam>
+            </configuration>
             <executions>
               <execution>
                 <id>javadoc</id>


### PR DESCRIPTION
This fixes javadoc generation with JDK >= 8 so that someone with write-permission to the jclouds.apache.org site can fix apache/jclouds-site#12

Corresponding JIRA-Issue: [JCLOUDS-1544](https://issues.apache.org/jira/browse/JCLOUDS-1544)
Note: This also applies to the 2.2.x branch, shall I create another PR for that?

Cheers
 -Fritz