### PR TITLE
Fix toolchain setup on jenkins

### DIFF
--- a/project/pom.xml
+++ b/project/pom.xml
@@ -1494,6 +1494,9 @@
           </plugin>
         </plugins>
       </build>
+      <properties>
+        <javadoc.opts></javadoc.opts>
+      </properties>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
This PR fixes the jenkins-specific case introduced by my PR #67 where maven is run by jdk8 and then the toolchain-plugin is used to downgrade the toolchain to jdk1.7.
This was tested successfully in 3 scenarios:

1. Maven executed by JDK7, jenkins profile deactivated
1. Maven executed by JDK8, jenkins profile deactivated
3. Maven executed by JDK8, jenkins profile activated and jdk.version set to 1.7

It will **not** work if maven is executed by JDK>=8 **and** jenkins profile is activated **and** jdk.version is set to anything > 1.7 (For that to work, you have to revert this patch)

In my humble opinion, jenkins-specific setup (or any CI for that matter) does not belong into a project's pom.xml. Instead, this should be solved entirely on jenkins itself. (e.g. by setting up a freestyle job instead of a maven job, setting JAVA_HOME in the job environment and then invoking maven in a shell task). This way, any hassle could have been avoided.

Cheers
 -Fritz