### PR TITLE
JCLOUDS-1545: Upgrade to OkHttp 2.7.5

### DIFF
--- a/apis/ec2/src/test/java/org/jclouds/ec2/internal/BaseEC2ApiMockTest.java
+++ b/apis/ec2/src/test/java/org/jclouds/ec2/internal/BaseEC2ApiMockTest.java
@@ -36,7 +36,6 @@ import org.jclouds.ec2.EC2ApiMetadata;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.inject.Module;
@@ -76,7 +75,7 @@ public class BaseEC2ApiMockTest {
    @BeforeMethod
    public void start() throws IOException {
       MockWebServer server = new MockWebServer();
-      server.play();
+      server.start();
       regionToServers.put(DEFAULT_REGION, server);
    }
 
@@ -99,7 +98,7 @@ public class BaseEC2ApiMockTest {
          describeRegionsResponse.append("<regionName>").append(region).append("</regionName>");
          if (!regionToServers.containsKey(region)) {
             MockWebServer server = new MockWebServer();
-            server.play();
+            server.start();
             regionToServers.put(region, server);
          }
          MockWebServer server = regionToServers.get(region);
@@ -130,7 +129,7 @@ public class BaseEC2ApiMockTest {
       RecordedRequest request = regionToServers.get(region).takeRequest();
       assertEquals(request.getMethod(), "POST");
       assertEquals(request.getPath(), "/");
-      assertEquals(new String(request.getBody(), Charsets.UTF_8).replaceAll("&Signature.*", ""), postParams);
+      assertEquals(request.getBody().readUtf8().replaceAll("&Signature.*", ""), postParams);
       return request;
    }
 }

--- a/apis/elasticstack/src/test/java/org/jclouds/elasticstack/ElasticStackMockTest.java
+++ b/apis/elasticstack/src/test/java/org/jclouds/elasticstack/ElasticStackMockTest.java
@@ -39,6 +39,8 @@ import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
 import com.squareup.okhttp.mockwebserver.RecordedRequest;
 
+import okio.Buffer;
+
 /**
  * Mock tests for the {@link ElasticStackApi} class.
  */
@@ -84,12 +86,14 @@ public class ElasticStackMockTest extends BaseMockWebServerTest {
       assertEquals(request.getHeader(HttpHeaders.AUTHORIZATION), "Basic dXVpZDphcGlrZXk=");
    }
 
-   private byte[] payloadFromResource(String resource) {
+   private Buffer payloadFromResource(String resource) {
+      Buffer buffer = new Buffer();
       try {
-         return toStringAndClose(getClass().getResourceAsStream(resource)).getBytes(Charsets.UTF_8);
+         buffer.write(toStringAndClose(getClass().getResourceAsStream(resource)).getBytes(Charsets.UTF_8));
       } catch (IOException e) {
          throw Throwables.propagate(e);
       }
+      return buffer;
    }
 
    @Override

--- a/apis/oauth/src/test/java/org/jclouds/oauth/v2/AuthorizationApiMockTest.java
+++ b/apis/oauth/src/test/java/org/jclouds/oauth/v2/AuthorizationApiMockTest.java
@@ -101,7 +101,7 @@ public class AuthorizationApiMockTest {
          server.enqueue(new MockResponse().setBody("{\n"
                  + "  \"access_token\" : \"1/8xbJqaOZXSUZbHLl5EOtu1pxz3fmmetKx9W8CV4t79M\",\n"
                  + "  \"token_type\" : \"Bearer\",\n" + "  \"expires_in\" : 3600\n" + "}"));
-         server.play();
+         server.start();
 
          AuthorizationApi api = api(server.getUrl("/"), P12_PRIVATE_KEY_CREDENTIALS);
 
@@ -113,7 +113,7 @@ public class AuthorizationApiMockTest {
          assertEquals(request.getHeader("Content-Type"), "application/x-www-form-urlencoded");
 
          assertEquals(
-                 new String(request.getBody(), UTF_8), //
+                 request.getBody().readUtf8(),
                  "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&"
                          +
                          // Base64 Encoded Header
@@ -134,7 +134,7 @@ public class AuthorizationApiMockTest {
       MockWebServer server = new MockWebServer();
       try {
          server.enqueue(new MockResponse().setResponseCode(400));
-         server.play();
+         server.start();
 
          AuthorizationApi api = api(server.getUrl("/"), P12_PRIVATE_KEY_CREDENTIALS);
          api.authorize(CLAIMS);
@@ -158,7 +158,7 @@ public class AuthorizationApiMockTest {
          server.enqueue(new MockResponse().setBody("{\n"
                  + "  \"access_token\" : \"1/8xbJqaOZXSUZbHLl5EOtu1pxz3fmmetKx9W8CV4t79M\",\n"
                  + "  \"token_type\" : \"Bearer\",\n" + "  \"expires_in\" : 3600\n" + "}"));
-         server.play();
+         server.start();
 
          AuthorizationApi api = api(server.getUrl("/"), CLIENT_CREDENTIALS_SECRET);
 
@@ -170,7 +170,7 @@ public class AuthorizationApiMockTest {
          assertEquals(request.getHeader("Content-Type"), "application/x-www-form-urlencoded");
 
          assertEquals(
-                 new String(request.getBody(), UTF_8), //
+                 request.getBody().readUtf8(),
                  "grant_type=client_credentials&client_id=" + identity
                          + "&client_secret=" + credential
                          + "&resource=" + encoded_resource);
@@ -190,7 +190,7 @@ public class AuthorizationApiMockTest {
          server.enqueue(new MockResponse().setBody("{\n"
                  + "  \"access_token\" : \"1/8xbJqaOZXSUZbHLl5EOtu1pxz3fmmetKx9W8CV4t79M\",\n"
                  + "  \"token_type\" : \"Bearer\",\n" + "  \"expires_in\" : 3600\n" + "}"));
-         server.play();
+         server.start();
 
          AuthorizationApi api = api(server.getUrl("/"), CLIENT_CREDENTIALS_P12_AND_CERTIFICATE);
          assertEquals(api.authorize(identity, CLIENT_CREDENTIALS_CLAIMS, resource, null), TOKEN);
@@ -201,7 +201,7 @@ public class AuthorizationApiMockTest {
          assertEquals(request.getHeader("Content-Type"), "application/x-www-form-urlencoded");
 
          assertEquals(
-                 new String(request.getBody(), UTF_8),
+                 request.getBody().readUtf8(),
                  "grant_type=client_credentials&" +
                          "client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&" +
                          "client_id=" + identity + "&" +

--- a/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/extensions/RoleAdminApiMockTest.java
+++ b/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/extensions/RoleAdminApiMockTest.java
@@ -90,7 +90,7 @@ public class RoleAdminApiMockTest extends BaseOpenStackMockTest<KeystoneApi> {
          assertExtensions(server);
          RecordedRequest createRoleRequest = server.takeRequest();
          assertEquals(createRoleRequest.getRequestLine(), "POST /OS-KSADM/roles HTTP/1.1");
-         assertEquals(new String(createRoleRequest.getBody()), "{\"role\":{\"name\":\"jclouds-role\"}}");
+         assertEquals(createRoleRequest.getBody().readUtf8(), "{\"role\":{\"name\":\"jclouds-role\"}}");
       } finally {
          server.shutdown();
       }

--- a/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/extensions/ServiceAdminApiMockTest.java
+++ b/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/extensions/ServiceAdminApiMockTest.java
@@ -119,7 +119,7 @@ public class ServiceAdminApiMockTest extends BaseOpenStackMockTest<KeystoneApi> 
          assertExtensions(server);
          RecordedRequest createServiceRequest = server.takeRequest();
          assertEquals(createServiceRequest.getRequestLine(), "POST /OS-KSADM/services HTTP/1.1");
-         String bodyRequest = new String(createServiceRequest.getBody());
+         String bodyRequest = createServiceRequest.getBody().readUtf8();
          assertEquals(
                bodyRequest,
                "{\"OS-KSADM:service\":{\"name\":\"jclouds-service-test\",\"type\":\"jclouds-service-type\",\"description\":\"jclouds-service-description\"}}");

--- a/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/extensions/TenantAdminApiMockTest.java
+++ b/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/extensions/TenantAdminApiMockTest.java
@@ -58,7 +58,7 @@ public class TenantAdminApiMockTest extends BaseOpenStackMockTest<KeystoneApi> {
          assertExtensions(server);
          RecordedRequest createTenantRequest = server.takeRequest();
          assertEquals(createTenantRequest.getRequestLine(), "POST /tenants HTTP/1.1");
-         assertEquals(new String(createTenantRequest.getBody()),
+         assertEquals(createTenantRequest.getBody().readUtf8(),
                "{\"tenant\":{\"name\":\"jclouds-tenant\",\"description\":\"jclouds-description\",\"enabled\":true}}");
       } finally {
          server.shutdown();
@@ -88,7 +88,7 @@ public class TenantAdminApiMockTest extends BaseOpenStackMockTest<KeystoneApi> {
          RecordedRequest updateTenantRequest = server.takeRequest();
          assertEquals(updateTenantRequest.getRequestLine(), "PUT /tenants/t1000 HTTP/1.1");
          assertEquals(
-               new String(updateTenantRequest.getBody()),
+               updateTenantRequest.getBody().readUtf8(),
                "{\"tenant\":{\"name\":\"jclouds-tenant-modified\",\"description\":\"jclouds-description-modified\",\"enabled\":false}}");
       } finally {
          server.shutdown();

--- a/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/extensions/UserAdminApiMockTest.java
+++ b/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v2_0/extensions/UserAdminApiMockTest.java
@@ -59,7 +59,7 @@ public class UserAdminApiMockTest extends BaseOpenStackMockTest<KeystoneApi> {
          RecordedRequest createUserRequest = server.takeRequest();
          assertEquals(createUserRequest.getRequestLine(), "POST /users HTTP/1.1");
          assertEquals(
-               new String(createUserRequest.getBody()),
+               createUserRequest.getBody().readUtf8(),
                "{\"user\":{\"name\":\"jqsmith\",\"tenantId\":\"12345\",\"password\":\"jclouds-password\",\"email\":\"john.smith@example.org\",\"enabled\":true}}");
       } finally {
          server.shutdown();
@@ -89,7 +89,7 @@ public class UserAdminApiMockTest extends BaseOpenStackMockTest<KeystoneApi> {
          RecordedRequest updateUserRequest = server.takeRequest();
          assertEquals(updateUserRequest.getRequestLine(), "PUT /users/u1000 HTTP/1.1");
          assertEquals(
-               new String(updateUserRequest.getBody()),
+               updateUserRequest.getBody().readUtf8(),
                "{\"user\":{\"name\":\"jqsmith-renamed\",\"email\":\"john.smith.renamed@example.org\",\"password\":\"jclouds-password\",\"enabled\":false}}");
       } finally {
          server.shutdown();

--- a/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v3/internal/BaseV3KeystoneApiMockTest.java
+++ b/apis/openstack-keystone/src/test/java/org/jclouds/openstack/keystone/v3/internal/BaseV3KeystoneApiMockTest.java
@@ -68,7 +68,7 @@ public class BaseV3KeystoneApiMockTest {
    @BeforeMethod
    public void start() throws IOException {
       server = new MockWebServer();
-      server.play();
+      server.start();
       
       ApiContext<KeystoneApi> ctx = ContextBuilder.newBuilder("openstack-keystone-3")
               .credentials("domain:identity", "credential")
@@ -178,7 +178,7 @@ public class BaseV3KeystoneApiMockTest {
    
    private void assertBody(RecordedRequest request, String body) {
       assertEquals(request.getHeader("Content-Type"), "application/json");
-      assertEquals(parser.parse(new String(request.getBody(), Charsets.UTF_8)), parser.parse(body));
+      assertEquals(parser.parse(request.getBody().readUtf8()), parser.parse(body));
    }
 
    protected Token tokenFromResource(String resource) {

--- a/apis/openstack-keystone/src/test/java/org/jclouds/openstack/v2_0/internal/BaseOpenStackMockTest.java
+++ b/apis/openstack-keystone/src/test/java/org/jclouds/openstack/v2_0/internal/BaseOpenStackMockTest.java
@@ -19,6 +19,7 @@ package org.jclouds.openstack.v2_0.internal;
 import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static org.jclouds.Constants.PROPERTY_MAX_RETRIES;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 import java.io.Closeable;
@@ -34,7 +35,6 @@ import org.jclouds.ContextBuilder;
 import org.jclouds.concurrent.config.ExecutorServiceModule;
 import org.jclouds.util.Strings2;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.net.HttpHeaders;
@@ -85,7 +85,7 @@ public class BaseOpenStackMockTest<A extends Closeable> {
 
    public static MockWebServer mockOpenStackServer() throws IOException {
       MockWebServer server = new MockWebServer();
-      server.play();
+      server.start();
       URL url = server.getUrl("");
       server.setDispatcher(getURLReplacingQueueDispatcher(url));
       return server;
@@ -187,7 +187,7 @@ public class BaseOpenStackMockTest<A extends Closeable> {
     * @see RecordedRequest
     */
    private void assertContentTypeIsJSON(RecordedRequest request) {
-      assertTrue(request.getHeaders().contains("Content-Type: application/json"));
+      assertNotNull(request.getHeaders().get("Content-Type: application/json"));
    }
 
    /**
@@ -224,7 +224,7 @@ public class BaseOpenStackMockTest<A extends Closeable> {
       JsonElement requestJson = null;  // to be compared
       JsonElement resourceJson;        // to be compared
       try {
-         requestJson = parser.parse(new String(request.getBody(), Charsets.UTF_8));
+         requestJson = parser.parse(request.getBody().readUtf8());
       } catch (Exception e) {
          Throwables.propagate(e);
       }

--- a/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/AuthenticationMockTest.java
+++ b/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/AuthenticationMockTest.java
@@ -16,7 +16,6 @@
  */
 package org.jclouds.openstack.swift.v1;
 
-import static com.google.common.base.Charsets.UTF_8;
 import static org.jclouds.openstack.swift.v1.features.AccountApiMockTest.accountResponse;
 import static org.testng.Assert.assertEquals;
 
@@ -63,7 +62,7 @@ public class AuthenticationMockTest extends BaseOpenStackMockTest<SwiftApi> {
          assertEquals(server.getRequestCount(), 2);
          RecordedRequest authRequest = server.takeRequest();
          assertEquals(authRequest.getRequestLine(), "POST /tokens HTTP/1.1");
-         assertEquals(new String(authRequest.getBody(), UTF_8), expectedPost);
+         assertEquals(authRequest.getBody().readUtf8(), expectedPost);
       } finally {
          server.shutdown();
       }

--- a/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/TempAuthMockTest.java
+++ b/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/TempAuthMockTest.java
@@ -100,10 +100,10 @@ public class TempAuthMockTest {
    @BeforeMethod
    public void start() throws IOException {
       tempAuthServer = new MockWebServer();
-      tempAuthServer.play();
+      tempAuthServer.start();
 
       swiftServer = new MockWebServer();
-      swiftServer.play();
+      swiftServer.start();
    }
 
    @AfterMethod(alwaysRun = true)

--- a/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/features/DynamicLargeObjectApiMockTest.java
+++ b/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/features/DynamicLargeObjectApiMockTest.java
@@ -60,7 +60,7 @@ public final class DynamicLargeObjectApiMockTest extends BaseOpenStackMockTest<S
          RecordedRequest uploadRequest = server.takeRequest();
          assertEquals(uploadRequest.getRequestLine(),
                "PUT /v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9/myContainer/myObjectTest1 HTTP/1.1");
-         assertEquals(new String(uploadRequest.getBody()), "data1");
+         assertEquals(uploadRequest.getBody().readUtf8(), "data1");
 
          RecordedRequest uploadRequestManifest = server.takeRequest();
          assertRequest(uploadRequestManifest, "PUT",

--- a/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/features/StaticLargeObjectApiMockTest.java
+++ b/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/features/StaticLargeObjectApiMockTest.java
@@ -67,7 +67,7 @@ public class StaticLargeObjectApiMockTest extends BaseOpenStackMockTest<SwiftApi
          assertRequest(replaceRequest, "PUT", "/v1/MossoCloudFS_5bcf396e-39dd-45ff-93a1-712b9aba90a9/myContainer/myObject?multipart-manifest=put");
          assertEquals(replaceRequest.getHeader(OBJECT_METADATA_PREFIX + "myfoo"), "Bar");
          assertEquals(
-               new String(replaceRequest.getBody()),
+               replaceRequest.getBody().readUtf8(),
          "[{\"path\":\"/mycontainer/objseg1\",\"etag\":\"0228c7926b8b642dfb29554cd1f00963\",\"size_bytes\":1468006}," +
           "{\"path\":\"/mycontainer/pseudodir/seg-obj2\",\"etag\":\"5bfc9ea51a00b790717eeb934fb77b9b\",\"size_bytes\":1572864}," +
           "{\"path\":\"/other-container/seg-final\",\"etag\":\"b9c3da507d2557c1ddc51f27c54bae51\",\"size_bytes\":256}]");
@@ -115,7 +115,7 @@ public class StaticLargeObjectApiMockTest extends BaseOpenStackMockTest<SwiftApi
          assertEquals(replaceRequest.getHeader("content-length"), Long.toString(byteLength));
 
          assertEquals(
-             new String(replaceRequest.getBody()),
+             replaceRequest.getBody().readUtf8(),
              expectedManifest);
       } finally {
          server.shutdown();
@@ -158,7 +158,7 @@ public class StaticLargeObjectApiMockTest extends BaseOpenStackMockTest<SwiftApi
          assertEquals(replaceRequest.getHeader("some-header1"), "some-header-value");
 
          assertEquals(
-               new String(replaceRequest.getBody()),
+               replaceRequest.getBody().readUtf8(),
                "[{\"path\":\"/mycontainer/objseg1\",\"etag\":\"0228c7926b8b642dfb29554cd1f00963\",\"size_bytes\":1468006}," +
                      "{\"path\":\"/mycontainer/pseudodir/seg-obj2\",\"etag\":\"5bfc9ea51a00b790717eeb934fb77b9b\",\"size_bytes\":1572864}," +
                      "{\"path\":\"/other-container/seg-final\",\"etag\":\"b9c3da507d2557c1ddc51f27c54bae51\",\"size_bytes\":256}]");

--- a/apis/s3/src/test/java/org/jclouds/s3/S3ClientMockTest.java
+++ b/apis/s3/src/test/java/org/jclouds/s3/S3ClientMockTest.java
@@ -63,7 +63,7 @@ public class S3ClientMockTest {
    public void testZeroLengthPutHasContentLengthHeader() throws IOException, InterruptedException {
       MockWebServer server = new MockWebServer();
       server.enqueue(new MockResponse().addHeader(ETAG, "ABCDEF"));
-      server.play();
+      server.start();
 
       S3Client client = getS3Client(server.getUrl("/"));
       S3Object nada = client.newS3Object();
@@ -74,15 +74,15 @@ public class S3ClientMockTest {
 
       RecordedRequest request = server.takeRequest();
       assertEquals(request.getRequestLine(), "PUT /bucket/object HTTP/1.1");
-      assertEquals(request.getHeaders(CONTENT_LENGTH), ImmutableList.of("0"));
-      assertThat(request.getHeaders(EXPECT)).isEmpty();
+      assertEquals(request.getHeaders().get(CONTENT_LENGTH), ImmutableList.of("0"));
+      assertThat(request.getHeaders().get(EXPECT)).isNull();
       server.shutdown();
    }
 
    public void testDirectorySeparator() throws IOException, InterruptedException {
       MockWebServer server = new MockWebServer();
       server.enqueue(new MockResponse().setBody("").addHeader(ETAG, "ABCDEF"));
-      server.play();
+      server.start();
 
       S3Client client = getS3Client(server.getUrl("/"));
       S3Object fileInDir = client.newS3Object();
@@ -93,7 +93,7 @@ public class S3ClientMockTest {
 
       RecordedRequest request = server.takeRequest();
       assertEquals(request.getRequestLine(), "PUT /bucket/someDir/fileName HTTP/1.1");
-      assertEquals(request.getHeaders(EXPECT), ImmutableList.of("100-continue"));
+      assertEquals(request.getHeaders().get(EXPECT), ImmutableList.of("100-continue"));
 
       server.shutdown();
    }
@@ -104,11 +104,11 @@ public class S3ClientMockTest {
               "   <LastModified>2009-10-28T22:32:00</LastModified>\n" +
               "   <ETag>\"9b2cf535f27731c974343645a3985328\"</ETag>\n" +
               " </CopyObjectResult>"));
-      server.play();
+      server.start();
       S3Client client = getS3Client(server.getUrl("/"));
       client.copyObject("sourceBucket", "apples#?:$&'\"<>čॐ", "destinationBucket", "destinationObject", CopyObjectOptions.NONE);
       RecordedRequest request = server.takeRequest();
-      assertEquals(request.getHeaders("x-amz-copy-source"), ImmutableList.of("/sourceBucket/apples%23%3F%3A%24%26%27%22%3C%3E%C4%8D%E0%A5%90"));
+      assertEquals(request.getHeaders().get("x-amz-copy-source"), ImmutableList.of("/sourceBucket/apples%23%3F%3A%24%26%27%22%3C%3E%C4%8D%E0%A5%90"));
       server.shutdown();
    }
 }

--- a/core/src/test/java/org/jclouds/http/JavaUrlHttpCommandExecutorServiceIntegrationTest.java
+++ b/core/src/test/java/org/jclouds/http/JavaUrlHttpCommandExecutorServiceIntegrationTest.java
@@ -62,7 +62,7 @@ public class JavaUrlHttpCommandExecutorServiceIntegrationTest extends BaseHttpCo
             return new MockResponse();
          }
       });
-      server.play();
+      server.start();
 
       HttpClient client =  api(HttpClient.class, server.getUrl("/").toString());
 

--- a/project/pom.xml
+++ b/project/pom.xml
@@ -225,8 +225,8 @@
     <guava.version>18.0</guava.version>
     <guava.osgi.import>com.google.common.*;version="[18.0,24.0.0)"</guava.osgi.import>
     <guice.version>3.0</guice.version>
-    <okhttp.version>2.2.0</okhttp.version>
-    <okio.osgi.import>okio;version="[1.2.0,1.3)"</okio.osgi.import>
+    <okhttp.version>2.7.5</okhttp.version>
+    <okio.osgi.import>okio;version="[2.7.5,2.8)"</okio.osgi.import>
     <surefire.version>2.17</surefire.version>
     <assertj-core.version>1.7.0</assertj-core.version>
     <assertj-guava.version>1.3.0</assertj-guava.version>

--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/internal/BaseAWSEC2ApiMockTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/internal/BaseAWSEC2ApiMockTest.java
@@ -48,7 +48,6 @@ import org.jclouds.rest.ConfiguresHttpApi;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.inject.Module;
@@ -122,7 +121,7 @@ public class BaseAWSEC2ApiMockTest {
    @BeforeMethod(alwaysRun = true)
    public void start() throws IOException {
       MockWebServer server = new MockWebServer();
-      server.play();
+      server.start();
       regionToServers.put(DEFAULT_REGION, server);
    }
 
@@ -145,7 +144,7 @@ public class BaseAWSEC2ApiMockTest {
          describeRegionsResponse.append("<regionName>").append(region).append("</regionName>");
          if (!regionToServers.containsKey(region)) {
             MockWebServer server = new MockWebServer();
-            server.play();
+            server.start();
             regionToServers.put(region, server);
          }
          MockWebServer server = regionToServers.get(region);
@@ -196,7 +195,7 @@ public class BaseAWSEC2ApiMockTest {
       assertThat(
             request.getHeader(AUTHORIZATION)).startsWith("AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20120416/" +
             region + "/ec2/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature=");
-      String body = new String(request.getBody(), Charsets.UTF_8);
+      String body = request.getBody().readUtf8();
       assertThat(body).contains("&Version=" + apiVersion);
       assertEquals(body.replace("&Version=" + apiVersion, ""), postParams);
       return request;

--- a/providers/azurecompute-arm/src/test/java/org/jclouds/azurecompute/arm/internal/BaseAzureComputeApiMockTest.java
+++ b/providers/azurecompute-arm/src/test/java/org/jclouds/azurecompute/arm/internal/BaseAzureComputeApiMockTest.java
@@ -74,7 +74,7 @@ public class BaseAzureComputeApiMockTest {
    @BeforeMethod
    public void start() throws IOException, URISyntaxException {
       server = new MockWebServer();
-      server.play();
+      server.start();
       
       context = ContextBuilder.newBuilder(testProviderMetadata())
               .credentials("mock", MOCK_BEARER_TOKEN)
@@ -180,7 +180,7 @@ public class BaseAzureComputeApiMockTest {
          throws InterruptedException {
       RecordedRequest request = assertSent(server, method, path);
       assertEquals(request.getHeader("Content-Type"), "application/json");
-      assertEquals(parser.parse(new String(request.getBody(), Charsets.UTF_8)), parser.parse(json));
+      assertEquals(parser.parse(request.getBody().readUtf8()), parser.parse(json));
       return request;
    }
    

--- a/providers/b2/src/test/java/org/jclouds/b2/features/B2TestUtils.java
+++ b/providers/b2/src/test/java/org/jclouds/b2/features/B2TestUtils.java
@@ -28,7 +28,6 @@ import org.jclouds.concurrent.config.ExecutorServiceModule;
 import org.jclouds.b2.B2Api;
 import org.jclouds.util.Strings2;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -57,7 +56,7 @@ final class B2TestUtils {
 
    static MockWebServer createMockWebServer() throws IOException {
       MockWebServer server = new MockWebServer();
-      server.play();
+      server.start();
       URL url = server.getUrl("");
       return server;
    }
@@ -104,7 +103,7 @@ final class B2TestUtils {
       JsonParser parser = new JsonParser();
       JsonElement requestJson;
       try {
-         requestJson = parser.parse(new String(request.getBody(), Charsets.UTF_8));
+         requestJson = parser.parse(request.getBody().readUtf8());
       } catch (Exception e) {
          throw Throwables.propagate(e);
       }
@@ -119,7 +118,7 @@ final class B2TestUtils {
     * @see RecordedRequest
     */
    private static void assertContentTypeIsJson(RecordedRequest request) {
-      assertThat(request.getHeaders()).contains("Content-Type: application/json");
+      assertThat(request.getHeaders().get("Content-Type")).isEqualTo("application/json");
    }
 
    /**

--- a/providers/b2/src/test/java/org/jclouds/b2/features/ObjectApiMockTest.java
+++ b/providers/b2/src/test/java/org/jclouds/b2/features/ObjectApiMockTest.java
@@ -285,7 +285,7 @@ public final class ObjectApiMockTest {
          request = server.takeRequest();
          assertThat(request.getMethod()).isEqualTo("GET");
          assertThat(request.getPath()).isEqualTo("/b2api/v2/b2_download_file_by_id?fileId=4_h4a48fe8875c6214145260818_f000000000000472a_d20140104_m032022_c001_v0000123_t0104");
-         assertThat(request.getHeaders()).contains("Range: bytes=42-69");
+         assertThat(request.getHeaders().get("Range")).isEqualTo("bytes=42-69");
       } finally {
          server.shutdown();
       }

--- a/providers/digitalocean2/src/test/java/org/jclouds/digitalocean2/internal/BaseDigitalOcean2ApiMockTest.java
+++ b/providers/digitalocean2/src/test/java/org/jclouds/digitalocean2/internal/BaseDigitalOcean2ApiMockTest.java
@@ -63,7 +63,7 @@ public class BaseDigitalOcean2ApiMockTest {
    @BeforeMethod
    public void start() throws IOException {
       server = new MockWebServer();
-      server.play();
+      server.start();
       ApiContext<DigitalOcean2Api> ctx = ContextBuilder.newBuilder("digitalocean2")
             .credentials("", MOCK_BEARER_TOKEN)
             .endpoint(url(""))
@@ -136,7 +136,7 @@ public class BaseDigitalOcean2ApiMockTest {
          throws InterruptedException {
       RecordedRequest request = assertSent(server, method, path);
       assertEquals(request.getHeader("Content-Type"), "application/json");
-      assertEquals(parser.parse(new String(request.getBody(), Charsets.UTF_8)), parser.parse(json));
+      assertEquals(parser.parse(request.getBody().readUtf8()), parser.parse(json));
       return request;
    }
 }

--- a/providers/dynect/src/test/java/org/jclouds/dynect/v3/DynectApiMockTest.java
+++ b/providers/dynect/src/test/java/org/jclouds/dynect/v3/DynectApiMockTest.java
@@ -61,7 +61,7 @@ public class DynectApiMockTest {
       MockWebServer server = new MockWebServer();
       server.enqueue(new MockResponse().setResponseCode(OK.getStatusCode()).setBody(session));
       server.enqueue(new MockResponse().setResponseCode(OK.getStatusCode()).setBody(running));
-      server.play();
+      server.start();
 
       DynECTApi api = mockDynectApi(server.getUrl("/").toString());
 
@@ -80,7 +80,7 @@ public class DynectApiMockTest {
       MockWebServer server = new MockWebServer();
       server.enqueue(new MockResponse().setResponseCode(OK.getStatusCode()).setBody(session));
       server.enqueue(new MockResponse().setResponseCode(OK.getStatusCode()).setBody(taskBlocking));
-      server.play();
+      server.start();
 
       DynECTApi api = mockDynectApi(server.getUrl("/").toString());
 
@@ -98,7 +98,7 @@ public class DynectApiMockTest {
       MockWebServer server = new MockWebServer();
       server.enqueue(new MockResponse().setResponseCode(OK.getStatusCode()).setBody(session));
       server.enqueue(new MockResponse().setResponseCode(OK.getStatusCode()).setBody(targetExists));
-      server.play();
+      server.start();
 
       DynECTApi api = mockDynectApi(server.getUrl("/").toString());
 

--- a/providers/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/features/ObjectApiMockTest.java
+++ b/providers/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/features/ObjectApiMockTest.java
@@ -20,7 +20,6 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.assertFalse;
-import static com.google.common.base.Charsets.UTF_8;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 import org.jclouds.googlecloudstorage.domain.DomainResourceReferences.DestinationPredefinedAcl;
@@ -117,7 +116,7 @@ public class ObjectApiMockTest extends BaseGoogleCloudStorageApiMockTest {
       RecordedRequest request = assertSent(server, "POST", "/upload/storage/v1/b/bucket_name/o" +
          "?uploadType=media&name=new_object&predefinedAcl=publicReadWrite", null);
       assertEquals(request.getHeader("Content-Type"), "text/plain");
-      assertEquals(new String(request.getBody(), UTF_8), testPayload);
+      assertEquals(request.getBody().readUtf8(), testPayload);
    }
 
    public void delete() throws Exception {
@@ -271,9 +270,9 @@ public class ObjectApiMockTest extends BaseGoogleCloudStorageApiMockTest {
             new ParseGoogleCloudStorageObject().expected());
 
       RecordedRequest request = assertSent(server, "POST", "/upload/storage/v1/b/bucket_name/o?uploadType=multipart", null);
-      assertTrue(new String(request.getBody(), UTF_8).contains(testPayload));
+      assertTrue(request.getBody().readUtf8().contains(testPayload));
 
-      assertTrue(new String(request.getBody(), UTF_8).contains(testPayload));
+      assertTrue(request.getBody().readUtf8().contains(testPayload));
       //TODO: this should be a more robust assertion about the formatting of the payload
    }
 

--- a/providers/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/internal/BaseGoogleCloudStorageApiMockTest.java
+++ b/providers/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/internal/BaseGoogleCloudStorageApiMockTest.java
@@ -16,7 +16,6 @@
  */
 package org.jclouds.googlecloudstorage.internal;
 
-import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.base.Throwables.propagate;
 import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -83,7 +82,7 @@ public class BaseGoogleCloudStorageApiMockTest {
    public void start() throws IOException {
       suffix.set(0);
       server = new MockWebServer();
-      server.play();
+      server.start();
    }
 
    protected String url(String path) {
@@ -129,7 +128,7 @@ public class BaseGoogleCloudStorageApiMockTest {
          throws InterruptedException {
       RecordedRequest request = assertSent(server, method, path, type);
       assertEquals(request.getHeader("Content-Type"), APPLICATION_JSON);
-      assertEquals(parser.parse(new String(request.getBody(), UTF_8)), parser.parse(json));
+      assertEquals(parser.parse(request.getBody().readUtf8()), parser.parse(json));
       return request;
    }
 

--- a/providers/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/internal/BaseGoogleComputeEngineApiMockTest.java
+++ b/providers/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/internal/BaseGoogleComputeEngineApiMockTest.java
@@ -16,7 +16,6 @@
  */
 package org.jclouds.googlecomputeengine.internal;
 
-import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.base.Throwables.propagate;
 import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -91,7 +90,7 @@ public class BaseGoogleComputeEngineApiMockTest {
    public void start() throws IOException {
       suffix.set(0);
       server = new MockWebServer();
-      server.play();
+      server.start();
    }
 
    protected String url(String path) {
@@ -138,7 +137,7 @@ public class BaseGoogleComputeEngineApiMockTest {
          throws InterruptedException {
       RecordedRequest request = assertSent(server, method, path);
       assertEquals(request.getHeader("Content-Type"), APPLICATION_JSON);
-      assertEquals(parser.parse(new String(request.getBody(), UTF_8)), parser.parse(json));
+      assertEquals(parser.parse(request.getBody().readUtf8()), parser.parse(json));
       return request;
    }
 

--- a/providers/packet/src/test/java/org/jclouds/packet/compute/internal/BasePacketApiMockTest.java
+++ b/providers/packet/src/test/java/org/jclouds/packet/compute/internal/BasePacketApiMockTest.java
@@ -65,7 +65,7 @@ public class BasePacketApiMockTest {
    @BeforeMethod
    public void start() throws IOException {
       server = new MockWebServer();
-      server.play();
+      server.start();
       ctx = ContextBuilder.newBuilder("packet")
             .credentials("", X_AUTHORIZATION_TOKEN)
             .endpoint(url(""))
@@ -140,7 +140,7 @@ public class BasePacketApiMockTest {
          throws InterruptedException {
       RecordedRequest request = assertSent(server, method, path);
       assertEquals(request.getHeader("Content-Type"), "application/json");
-      assertEquals(parser.parse(new String(request.getBody(), Charsets.UTF_8)), parser.parse(json));
+      assertEquals(parser.parse(request.getBody().readUtf8()), parser.parse(json));
       return request;
    }
 }

--- a/providers/profitbricks/src/test/java/org/jclouds/profitbricks/compute/config/StatusPredicateTest.java
+++ b/providers/profitbricks/src/test/java/org/jclouds/profitbricks/compute/config/StatusPredicateTest.java
@@ -36,6 +36,7 @@ import com.google.common.base.Predicate;
 import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
 
+import okio.Buffer;
 
 /**
  * Test class for {@link DataCenterProvisioningStatePredicate} and {@link ServerStatusPredicate}
@@ -47,8 +48,8 @@ public class StatusPredicateTest extends BaseProfitBricksMockTest {
    public void testDataCenterPredicate() throws Exception {
       MockWebServer server = mockWebServer();
 
-      byte[] payloadInProcess = payloadFromResource("/datacenter/datacenter-state-inprocess.xml");
-      byte[] payloadAvailable = payloadFromResource("/datacenter/datacenter-state.xml");
+      Buffer payloadInProcess = payloadFromResource("/datacenter/datacenter-state-inprocess.xml");
+      Buffer payloadAvailable = payloadFromResource("/datacenter/datacenter-state.xml");
 
       // wait 3 times
       server.enqueue(new MockResponse().setBody(payloadInProcess));
@@ -80,8 +81,8 @@ public class StatusPredicateTest extends BaseProfitBricksMockTest {
    public void testServerPredicate() throws Exception {
       MockWebServer server = mockWebServer();
 
-      byte[] payloadInProcess = payloadFromResource("/server/server-state-inprocess.xml");
-      byte[] payloadAvailable = payloadFromResource("/server/server.xml");
+      Buffer payloadInProcess = payloadFromResource("/server/server-state-inprocess.xml");
+      Buffer payloadAvailable = payloadFromResource("/server/server.xml");
 
       // wait 3 times
       server.enqueue(new MockResponse().setBody(payloadInProcess));
@@ -113,8 +114,8 @@ public class StatusPredicateTest extends BaseProfitBricksMockTest {
    public void testSnapshotPredicate() throws Exception {
       MockWebServer server = mockWebServer();
 
-      byte[] payloadInProcess = payloadFromResource("/snapshot/snapshot-state-inprocess.xml");
-      byte[] payloadAvailable = payloadFromResource("/snapshot/snapshot.xml");
+      Buffer payloadInProcess = payloadFromResource("/snapshot/snapshot-state-inprocess.xml");
+      Buffer payloadAvailable = payloadFromResource("/snapshot/snapshot.xml");
 
       // wait 3 times
       server.enqueue(new MockResponse().setBody(payloadInProcess));

--- a/providers/profitbricks/src/test/java/org/jclouds/profitbricks/internal/BaseProfitBricksMockTest.java
+++ b/providers/profitbricks/src/test/java/org/jclouds/profitbricks/internal/BaseProfitBricksMockTest.java
@@ -38,6 +38,8 @@ import com.google.inject.Module;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
 import com.squareup.okhttp.mockwebserver.RecordedRequest;
 
+import okio.Buffer;
+
 /**
  * Base class for all ProfitBricks mock test
  */
@@ -74,16 +76,18 @@ public class BaseProfitBricksMockTest {
 
    public static MockWebServer mockWebServer() throws IOException {
       MockWebServer server = new MockWebServer();
-      server.play();
+      server.start();
       return server;
    }
 
-   public byte[] payloadFromResource(String resource) {
+   public Buffer payloadFromResource(String resource) {
+      Buffer buffer = new Buffer();
       try {
-         return toStringAndClose(getClass().getResourceAsStream(resource)).getBytes(Charsets.UTF_8);
+         buffer.write(toStringAndClose(getClass().getResourceAsStream(resource)).getBytes(Charsets.UTF_8));
       } catch (IOException e) {
          throw Throwables.propagate(e);
       }
+      return buffer;
    }
 
    protected static String payloadSoapWithBody(String body) {
@@ -98,7 +102,7 @@ public class BaseProfitBricksMockTest {
    }
 
    protected static void assertRequestHasCommonProperties(final RecordedRequest request, String content) {
-      assertEquals(new String(request.getBody()), payloadSoapWithBody(content));
+      assertEquals(request.getBody().readUtf8(), payloadSoapWithBody(content));
       assertRequestHasCommonProperties(request);
    }
 }

--- a/providers/softlayer/src/test/java/org/jclouds/softlayer/internal/BaseSoftLayerMockTest.java
+++ b/providers/softlayer/src/test/java/org/jclouds/softlayer/internal/BaseSoftLayerMockTest.java
@@ -37,6 +37,8 @@ import com.google.inject.Module;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
 import com.squareup.okhttp.mockwebserver.RecordedRequest;
 
+import okio.Buffer;
+
 /**
  * Base class for all SoftLayer mock tests.
  */
@@ -54,12 +56,14 @@ public class BaseSoftLayerMockTest extends BaseMockWebServerTest {
       return new JavaUrlHttpCommandExecutorServiceModule();
    }
 
-   public byte[] payloadFromResource(String resource) {
+   public Buffer payloadFromResource(String resource) {
+      Buffer buffer = new Buffer();
       try {
-         return toStringAndClose(getClass().getResourceAsStream(resource)).getBytes(Charsets.UTF_8);
+         buffer.write(toStringAndClose(getClass().getResourceAsStream(resource)).getBytes(Charsets.UTF_8));
       } catch (IOException e) {
          throw Throwables.propagate(e);
       }
+      return buffer;
    }
 
    protected RecordedRequest assertSent(MockWebServer server, String method, String path) throws InterruptedException {


### PR DESCRIPTION
This allows creating an SSL certificate with 2048-bit RSA which
enables newer Java versions to run integration tests.  Tweak okhttp
tests which do not allow zero-length requests without bodies.