### PR TITLE
JCLOUDS-1546: Support GCS Archive storage class

### DIFF
--- a/providers/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/domain/DomainResourceReferences.java
+++ b/providers/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/domain/DomainResourceReferences.java
@@ -86,6 +86,7 @@ public final class DomainResourceReferences {
    }
 
    public enum StorageClass {
+      ARCHIVE(Tier.ARCHIVE),
       COLDLINE(Tier.ARCHIVE),
       DURABLE_REDUCED_AVAILABILITY(Tier.STANDARD),
       MULTI_REGIONAL(Tier.STANDARD),
@@ -103,7 +104,7 @@ public final class DomainResourceReferences {
          switch (tier) {
          case STANDARD: return StorageClass.STANDARD;
          case INFREQUENT: return StorageClass.NEARLINE;
-         case ARCHIVE: return StorageClass.COLDLINE;
+         case ARCHIVE: return StorageClass.ARCHIVE;
          }
          throw new IllegalArgumentException("invalid tier: " + tier);
       }

--- a/providers/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/features/BucketApiLiveTest.java
+++ b/providers/google-cloud-storage/src/test/java/org/jclouds/googlecloudstorage/features/BucketApiLiveTest.java
@@ -60,6 +60,8 @@ public class BucketApiLiveTest extends BaseGoogleCloudStorageApiLiveTest {
 
    private static final String BUCKET_NAME_COLDLINE = "jcloudstestbucketcoldline" + (int) (Math.random() * 10000);
 
+   private static final String BUCKET_NAME_ARCHIVE = "jcloudstestbucketarchive" + (int) (Math.random() * 10000);
+
    private static final String BUCKET_NAME_MULTI_REGIONAL = "jcloudstestbucketmultiregional" + (int) (Math.random() * 10000);
 
    private static final String BUCKET_NAME_NEARLINE = "jcloudstestbucketnearline" + (int) (Math.random() * 10000);
@@ -139,6 +141,23 @@ public class BucketApiLiveTest extends BaseGoogleCloudStorageApiLiveTest {
       assertThat(response.storageClass()).isEqualTo(StorageClass.COLDLINE);
 
       api().deleteBucket(BUCKET_NAME_COLDLINE);
+   }
+
+   @Test(groups = "live")
+   public void testCreateBucketArchive() {
+      BucketTemplate template = new BucketTemplate()
+               .name(BUCKET_NAME_ARCHIVE)
+               .location(Location.US)
+               .storageClass(StorageClass.ARCHIVE);
+
+      Bucket response = api().createBucket(PROJECT_NUMBER, template);
+
+      assertNotNull(response);
+      assertEquals(response.name(), BUCKET_NAME_ARCHIVE);
+      assertEquals(response.location(), Location.US);
+      assertThat(response.storageClass()).isEqualTo(StorageClass.ARCHIVE);
+
+      api().deleteBucket(BUCKET_NAME_ARCHIVE);
    }
 
    @Test(groups = "live")


### PR DESCRIPTION
Also change portable abstraction mapping for `Tier.ARCHIVE`.