### PR TITLE
JCLOUDS-912: JCLOUDS-1547: GCS InputStream single-part upload

### DIFF
--- a/core/src/main/java/org/jclouds/http/internal/PayloadEnclosingImpl.java
+++ b/core/src/main/java/org/jclouds/http/internal/PayloadEnclosingImpl.java
@@ -98,6 +98,14 @@ public class PayloadEnclosingImpl implements PayloadEnclosing {
    }
 
    @Override
+   public void resetPayload(boolean release) {
+      if (release && payload != null) {
+         payload.release();
+      }
+      payload = null;
+   }
+
+   @Override
    public int hashCode() {
       final int prime = 31;
       int result = 1;

--- a/core/src/main/java/org/jclouds/io/PayloadEnclosing.java
+++ b/core/src/main/java/org/jclouds/io/PayloadEnclosing.java
@@ -48,4 +48,5 @@ public interface PayloadEnclosing {
    @Nullable
    Payload getPayload();
 
+   void resetPayload(boolean release);
 }

--- a/providers/b2/src/test/java/org/jclouds/b2/blobstore/integration/B2BlobIntegrationLiveTest.java
+++ b/providers/b2/src/test/java/org/jclouds/b2/blobstore/integration/B2BlobIntegrationLiveTest.java
@@ -80,9 +80,19 @@ public final class B2BlobIntegrationLiveTest extends BaseBlobIntegrationTest {
    }
 
    @Override
-   public void testPutIncorrectContentMD5() throws InterruptedException, IOException {
+   public void testPutIncorrectContentMD5ByteSource() throws InterruptedException, IOException {
       try {
-         super.testPutIncorrectContentMD5();
+         super.testPutIncorrectContentMD5ByteSource();
+         failBecauseExceptionWasNotThrown(AssertionError.class);
+      } catch (AssertionError ae) {
+         throw new SkipException("B2 does not enforce Content-MD5", ae);
+      }
+   }
+
+   @Override
+   public void testPutIncorrectContentMD5InputStream() throws InterruptedException, IOException {
+      try {
+         super.testPutIncorrectContentMD5InputStream();
          failBecauseExceptionWasNotThrown(AssertionError.class);
       } catch (AssertionError ae) {
          throw new SkipException("B2 does not enforce Content-MD5", ae);

--- a/providers/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/binders/MultipartUploadBinder.java
+++ b/providers/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/binders/MultipartUploadBinder.java
@@ -57,6 +57,7 @@ public final class MultipartUploadBinder implements MapBinder {
       Part jsonPart = Part.create("Metadata", jsonPayload, new Part.PartOptions().contentType(APPLICATION_JSON));
       Part mediaPart = Part.create(template.name(), payload, new Part.PartOptions().contentType(contentType));
 
+      request.resetPayload(/*release=*/ false);
       request.setPayload(new MultipartForm(BOUNDARY_HEADER, jsonPart, mediaPart));
       // HeaderPart
       request.toBuilder().replaceHeader(CONTENT_TYPE, "Multipart/related; boundary= " + BOUNDARY_HEADER).build();

--- a/providers/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/blobstore/GoogleCloudStorageBlobStore.java
+++ b/providers/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/blobstore/GoogleCloudStorageBlobStore.java
@@ -211,7 +211,7 @@ public final class GoogleCloudStorageBlobStore extends BaseBlobStore {
    public String putBlob(String container, Blob blob, PutOptions options) {
       long length = checkNotNull(blob.getPayload().getContentMetadata().getContentLength());
 
-      if (length != 0 && (options.isMultipart() || !blob.getPayload().isRepeatable())) {
+      if (length != 0 && options.isMultipart()) {
          // JCLOUDS-912 prevents using single-part uploads with InputStream payloads.
          // Work around this with multi-part upload which buffers parts in-memory.
          return putMultipartBlob(container, blob, options);


### PR DESCRIPTION
Previously this provider worked around a RestAnnotationProcessor quirk
by using multi-part uploads for InputStream payloads.  Instead work
around the quirk another way which allows a single-part upload.  This
allows inclusion of the Content-MD5 header during object creation.
Backfill tests with both ByteSource and InputStream inputs.