### PR TITLE
JCLOUDS-1491 Jclouds uses a deprecated version of Guava to support Az…

### DIFF
--- a/core/src/main/java/org/jclouds/predicates/validators/DnsNameValidator.java
+++ b/core/src/main/java/org/jclouds/predicates/validators/DnsNameValidator.java
@@ -46,11 +46,10 @@ public class DnsNameValidator extends Validator<String> {
    }
 
    public void validate(String name) {
-
-      if (name == null || name.length() < min || name.length() > max)
+      if (name == null || name.isEmpty() || name.length() < min || name.length() > max)
          throw exception(name, "Can't be null or empty. Length must be " + min + " to " + max
                   + " symbols.");
-      if (CharMatcher.JAVA_LETTER_OR_DIGIT.indexIn(name) != 0)
+      if (!Character.isLetterOrDigit(name.charAt(0)))
          throw exception(name, "Should start with letter/number");
       if (!name.toLowerCase().equals(name))
          throw exception(name, "Should be only lowercase");


### PR DESCRIPTION
…ure storage

DnsNameValidator.java uses a deprecated guava APIs in code that is used
 to support Azure cloud storage. When forcing the use of more recent guava
 versions, the code fails with NoSuchFieldError.

However, CharMatcher.JAVA_LETTER_OR_DIGIT has been removed in guava 26.0,
 and CharMatcher.javaLetterOrDigit() should be used instead since guava
 19.0. Note that CharMatcher.javaLetterOrDigit() was immediately
 deprecated in Guava 26.0, and java.lang.Character.isLetterOrDigit(int)
 should be used instead.

This commit replaces the use of this deprecated API by
 java.lang.Character.isLetterOrDigit(int).
 It is no worse than the previous code.

(If I understand correctly, updating the guava version is a challenge due to
dependencies on Apache Karaf anyway)