### PR TITLE
JCLOUDS-1542 Java 11 warns of illegal reflective access

### DIFF
--- a/core/src/main/java/org/jclouds/reflect/Reflection2.java
+++ b/core/src/main/java/org/jclouds/reflect/Reflection2.java
@@ -153,15 +153,23 @@ public class Reflection2 {
          .newBuilder().build(new CacheLoader<TypeToken<?>, Set<Invokable<?, ?>>>() {
             public Set<Invokable<?, ?>> load(TypeToken<?> key) {
                ImmutableSet.Builder<Invokable<?, ?>> builder = ImmutableSet.<Invokable<?, ?>> builder();
-               for (Constructor<?> ctor : key.getRawType().getDeclaredConstructors()) {
-                  ctor.setAccessible(true);
+               Class<?> raw = key.getRawType();
+               for (Constructor<?> ctor : raw.getDeclaredConstructors()) {
+                  if (!coreJavaClass(raw)) {
+                     // In JDK 11 up to 14, the only uses for `java.beans.ConstructorProperties` annotation
+                     // are in the `java.awt`, `java.beans` and `javax.swing` packages.
+                     // Since these constructors are public, there is no need to call `setAccessible()`
+                     ctor.setAccessible(true);
+                  }
                   builder.add(key.constructor(ctor));
                }
                // Look for factory methods, if this is an abstract type.
-               if (Modifier.isAbstract(key.getRawType().getModifiers())) {
-                  for (Invokable<?, Object> method : methods(key.getRawType())){
+               if (Modifier.isAbstract(raw.getModifiers())) {
+                  for (Invokable<?, Object> method : methods(raw)){
                      if (method.isStatic() && method.getReturnType().equals(key)) {
-                        method.setAccessible(true);
+                        if (!coreJavaClass(raw)) {
+                           method.setAccessible(true);
+                        }
                         builder.add(method);
                      }
                   }


### PR DESCRIPTION
With Java 11, an illegal reflective access is output for the google cloud storage blobstore.

    WARNING: An illegal reflective access operation has occurred
    WARNING: Illegal reflective access by org.jclouds.reflect.Reflection2$1 (file:/.../jclouds-core.jar) to constructor java.lang.String(char[],int,int,java.lang.Void)
    WARNING: Please consider reporting this to the maintainers of org.jclouds.reflect.Reflection2$1
    WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
    WARNING: All illegal access operations will be denied in a future release

Indeed, JClouds calls `setAccessible(true)` on the package protected constructor
     `java.lang.String(char[],int,int,java.lang.Void)`.
Investigating the code, it turns out it is looking for constructors annotated with any of:
* java.beans.ConstructorProperties
* org.jclouds.json.SerializedNames
* com.google.inject.Inject

But `String` being defined in `java.base` module, it is impossible
     that it will be annotated with any of these annotation.

This commit is complementary to JClouds commit db4e4af931ef19f582b85f02efb93e50f1c5d01c .

&nbsp;

Reflection2.java:
Do not call `setAccessible(true)` on core java constructors and methods.

&nbsp;

For reference, here is the stacktrace of this illegal access warning:

    java.lang.String.<init>(String.java:3208)
    java.lang.String.<init>(String.java:251)
    java.util.StringJoiner.compactElts(StringJoiner.java:250)
    java.util.StringJoiner.toString(StringJoiner.java:173)
    jdk.internal.module.IllegalAccessLogger.loudWarning(IllegalAccessLogger.java:339)
    jdk.internal.module.IllegalAccessLogger.log(IllegalAccessLogger.java:288)
    jdk.internal.module.IllegalAccessLogger.log(IllegalAccessLogger.java:261)
    jdk.internal.module.IllegalAccessLogger.logIfOpenedForIllegalAccess(IllegalAccessLogger.java:226)
    java.lang.reflect.AccessibleObject.logIfOpenedForIllegalAccess(AccessibleObject.java:366)
    java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:325)
    java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:280)
    java.lang.reflect.Constructor.checkCanSetAccessible(Constructor.java:189)
    java.lang.reflect.Constructor.setAccessible(Constructor.java:182)
    org.jclouds.reflect.Reflection2$1.load(Reflection2$1.java:157)
    org.jclouds.reflect.Reflection2$1.load(Reflection2$1.java:153)
    com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache$LoadingValueReference.java:3529)
    com.google.common.cache.LocalCache$Segment.loadSync(LocalCache$Segment.java:2278)
    com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache$Segment.java:2155)
    com.google.common.cache.LocalCache$Segment.get(LocalCache$Segment.java:2045)
    com.google.common.cache.LocalCache.get(LocalCache.java:3953)
    com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:3976)
    com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache$LocalLoadingCache.java:4960)
    org.jclouds.reflect.Reflection2.get(Reflection2.java:346)
    org.jclouds.reflect.Reflection2.constructors(Reflection2.java:100)
    org.jclouds.json.internal.NamingStrategies$AnnotationConstructorNamingStrategy.getDeserializer(NamingStrategies$AnnotationConstructorNamingStrategy.java:271)
    org.jclouds.json.internal.DeserializationConstructorAndReflectiveTypeAdapterFactory.create(DeserializationConstructorAndReflectiveTypeAdapterFactory.java:125)
    com.google.gson.Gson.getAdapter(Gson.java:458)
    org.jclouds.json.gson.internal.bind.ReflectiveTypeAdapterFactory.createBoundField(ReflectiveTypeAdapterFactory.java:117)
    org.jclouds.json.gson.internal.bind.ReflectiveTypeAdapterFactory.getBoundFields(ReflectiveTypeAdapterFactory.java:166)
    org.jclouds.json.gson.internal.bind.ReflectiveTypeAdapterFactory.create(ReflectiveTypeAdapterFactory.java:102)
    com.google.gson.Gson.getAdapter(Gson.java:458)
    com.google.gson.Gson.toJson(Gson.java:696)
    com.google.gson.Gson.toJson(Gson.java:683)
    com.google.gson.Gson.toJson(Gson.java:638)
    com.google.gson.Gson.toJson(Gson.java:618)
    org.jclouds.json.internal.GsonWrapper.toJson(GsonWrapper.java:65)
    org.jclouds.oauth.v2.functions.ClaimsToAssertion.apply(ClaimsToAssertion.java:59)
    org.jclouds.oauth.v2.functions.ClaimsToAssertion.apply(ClaimsToAssertion.java:43)
    org.jclouds.rest.internal.RestAnnotationProcessor.getParamValue(RestAnnotationProcessor.java:829)
    org.jclouds.rest.internal.RestAnnotationProcessor.getFormParamKeyValues(RestAnnotationProcessor.java:847)
    org.jclouds.rest.internal.RestAnnotationProcessor.addFormParams(RestAnnotationProcessor.java:435)
    org.jclouds.rest.internal.RestAnnotationProcessor.apply(RestAnnotationProcessor.java:258)
    org.jclouds.rest.internal.RestAnnotationProcessor.apply(RestAnnotationProcessor.java:137)
    org.jclouds.rest.internal.InvokeHttpMethod.toCommand(InvokeHttpMethod.java:189)
    org.jclouds.rest.internal.InvokeHttpMethod.invoke(InvokeHttpMethod.java:85)
    org.jclouds.rest.internal.InvokeHttpMethod.apply(InvokeHttpMethod.java:74)
    org.jclouds.rest.internal.InvokeHttpMethod.apply(InvokeHttpMethod.java:45)
    org.jclouds.rest.internal.DelegatesToInvocationFunction.handle(DelegatesToInvocationFunction.java:156)
    org.jclouds.rest.internal.DelegatesToInvocationFunction.invoke(DelegatesToInvocationFunction.java:123)
    com.sun.proxy.$Proxy49.authorize(Unknown Source)
    org.jclouds.oauth.v2.filters.JWTBearerTokenFlow$AuthorizeToken.load(JWTBearerTokenFlow$AuthorizeToken.java:84)
    org.jclouds.oauth.v2.filters.JWTBearerTokenFlow$AuthorizeToken.load(JWTBearerTokenFlow$AuthorizeToken.java:68)
    com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache$LoadingValueReference.java:3529)
    com.google.common.cache.LocalCache$Segment.loadSync(LocalCache$Segment.java:2278)
    com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache$Segment.java:2155)
    com.google.common.cache.LocalCache$Segment.get(LocalCache$Segment.java:2045)
    com.google.common.cache.LocalCache.get(LocalCache.java:3953)
    com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:3976)
    com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache$LocalLoadingCache.java:4960)
    com.google.common.cache.LocalCache$LocalLoadingCache.getUnchecked(LocalCache$LocalLoadingCache.java:4966)
    org.jclouds.oauth.v2.filters.JWTBearerTokenFlow.filter(JWTBearerTokenFlow.java:99)
    org.jclouds.http.internal.BaseHttpCommandExecutorService.invoke(BaseHttpCommandExecutorService.java:90)
    org.jclouds.rest.internal.InvokeHttpMethod.invoke(InvokeHttpMethod.java:91)
    org.jclouds.rest.internal.InvokeHttpMethod.apply(InvokeHttpMethod.java:74)
    org.jclouds.rest.internal.InvokeHttpMethod.apply(InvokeHttpMethod.java:45)
    org.jclouds.reflect.FunctionalReflection$FunctionalInvocationHandler.handleInvocation(FunctionalReflection.java:117)
    com.google.common.reflect.AbstractInvocationHandler.invoke(AbstractInvocationHandler.java:86)
    com.sun.proxy.$Proxy54.simpleUpload(Unknown Source)
    org.jclouds.googlecloudstorage.blobstore.GoogleCloudStorageBlobStore.uploadMultipartPart(GoogleCloudStorageBlobStore.java:422)
    org.jclouds.blobstore.internal.BaseBlobStore$BlobUploader.call(BaseBlobStore.java:415)
    org.jclouds.blobstore.internal.BaseBlobStore$BlobUploader.call(BaseBlobStore.java:402)
    com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:125)
    com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:69)
    com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:78)
    java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
    java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor$Worker.java:628)
    java.lang.Thread.run(Thread.java:834)