### PR TITLE
JCLOUDS-1473 add INTELLIGENT_TIERING enum

### DIFF
--- a/apis/s3/src/main/java/org/jclouds/s3/domain/ObjectMetadata.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/domain/ObjectMetadata.java
@@ -37,6 +37,7 @@ public interface ObjectMetadata extends Comparable<ObjectMetadata> {
       STANDARD(Tier.STANDARD),
       STANDARD_IA(Tier.INFREQUENT),
       ONEZONE_IA(Tier.INFREQUENT),
+      INTELLIGENT_TIERING(Tier.STANDARD),
       REDUCED_REDUNDANCY(Tier.STANDARD),
       GLACIER(Tier.ARCHIVE),
       DEEP_ARCHIVE(Tier.ARCHIVE);


### PR DESCRIPTION
To solve the following stacktrace:

`java.lang.IllegalArgumentException: No enum constant org.jclouds.s3.domain.ObjectMetadata.StorageClass.INTELLIGENT_TIERING
        at java.lang.Enum.valueOf(Enum.java:238)
        at org.jclouds.s3.domain.ObjectMetadata$StorageClass.valueOf(ObjectMetadata.java:36)
        at org.jclouds.s3.functions.ParseObjectMetadataFromHeaders.apply(ParseObjectMetadataFromHeaders.java:81)
        at org.jclouds.s3.functions.ParseObjectFromHeadersAndHttpContent.apply(ParseObjectFromHeadersAndHttpContent.java:48)
        at org.jclouds.s3.functions.ParseObjectFromHeadersAndHttpContent.apply(ParseObjectFromHeadersAndHttpContent.java:34)
        at org.jclouds.rest.internal.InvokeHttpMethod.invoke(InvokeHttpMethod.java:91)
        at org.jclouds.rest.internal.InvokeHttpMethod.apply(InvokeHttpMethod.java:74)
        at org.jclouds.rest.internal.InvokeHttpMethod.apply(InvokeHttpMethod.java:45)
        at org.jclouds.rest.internal.DelegatesToInvocationFunction.handle(DelegatesToInvocationFunction.java:156)
        at org.jclouds.rest.internal.DelegatesToInvocationFunction.invoke(DelegatesToInvocationFunction.java:123)
        at com.sun.proxy.$Proxy150.getObject(Unknown Source)
        at org.jclouds.s3.blobstore.S3BlobStore.getBlob(S3BlobStore.java:235)
        at org.jclouds.blobstore.internal.BaseBlobStore.getBlob(BaseBlobStore.java:217)`