### PR TITLE
JCLOUDS-1552: Do not attempt to parse empty payload

### DIFF
--- a/apis/sts/src/main/java/org/jclouds/aws/util/AWSUtils.java
+++ b/apis/sts/src/main/java/org/jclouds/aws/util/AWSUtils.java
@@ -19,6 +19,7 @@ package org.jclouds.aws.util;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.jclouds.aws.reference.AWSConstants.PROPERTY_HEADER_TAG;
+import static org.jclouds.http.HttpUtils.closeClientButKeepContentStream;
 
 import java.util.Collection;
 import java.util.Map;
@@ -82,7 +83,8 @@ public class AWSUtils {
    }
 
    public AWSError parseAWSErrorFromContent(HttpRequest request, HttpResponse response) {
-      if (response.getPayload() == null)
+      byte[] actualPayload = response.getPayload() != null ? closeClientButKeepContentStream(response) : null;
+      if (actualPayload == null || actualPayload.length == 0)
          return null;
       if ("text/plain".equals(response.getPayload().getContentMetadata().getContentType()))
          return null;

--- a/apis/sts/src/test/java/org/jclouds/aws/util/AWSUtilsTest.java
+++ b/apis/sts/src/test/java/org/jclouds/aws/util/AWSUtilsTest.java
@@ -17,8 +17,13 @@
 package org.jclouds.aws.util;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.anyString;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.mock;
 import static org.easymock.EasyMock.replay;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
@@ -32,6 +37,8 @@ import org.jclouds.domain.Credentials;
 import org.jclouds.http.HttpCommand;
 import org.jclouds.http.HttpRequest;
 import org.jclouds.http.HttpResponse;
+import org.jclouds.io.payloads.StringPayload;
+import org.jclouds.logging.Logger;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
@@ -85,6 +92,20 @@ public class AWSUtilsTest {
    public void testNoExceptionParsingTextPlain() {
       HttpResponse response = HttpResponse.builder().statusCode(BAD_REQUEST.getStatusCode()).payload("foo bar").build();
       response.getPayload().getContentMetadata().setContentType(TEXT_PLAIN);
+      assertNull(utils.parseAWSErrorFromContent(command.getCurrentRequest(), response));
+   }
+
+   /**
+    * Do not attempt to parse empty payload.
+    */
+   @Test
+   public void testNoExceptionEmptyPayload() {
+      utils.logger = mock(Logger.class);
+      utils.logger.warn(anyObject(Throwable.class), anyString());
+      expectLastCall().andThrow(new IllegalStateException("log spam"));
+      replay(utils.logger);
+      HttpResponse response = HttpResponse.builder().statusCode(NOT_FOUND.getStatusCode()).payload(new StringPayload("")).build();
+      response.getPayload().getContentMetadata().setContentType("application/unknown");
       assertNull(utils.parseAWSErrorFromContent(command.getCurrentRequest(), response));
    }
 

--- a/core/src/main/java/org/jclouds/http/HttpUtils.java
+++ b/core/src/main/java/org/jclouds/http/HttpUtils.java
@@ -121,8 +121,9 @@ public class HttpUtils {
 
    public static byte[] toByteArrayOrNull(PayloadEnclosing response) {
       if (response.getPayload() != null) {
-         InputStream input = response.getPayload().getInput();
+         InputStream input = null;
          try {
+            input = response.getPayload().openStream();
             return toByteArray(input);
          } catch (IOException e) {
             propagate(e);


### PR DESCRIPTION
In  case of empty response, AWSUtil returns null, but produces WARN logspam.

https://issues.apache.org/jira/browse/JCLOUDS-1552