### PR TITLE
Initial cleanup of maven set up in the parents' module

### DIFF
--- a/apis/chef/pom.xml
+++ b/apis/chef/pom.xml
@@ -63,11 +63,6 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
-    <!--  for ohai -->
-    <dependency>
-      <groupId>com.google.inject.extensions</groupId>
-      <artifactId>guice-multibindings</artifactId>
-    </dependency>
     <!--  for transient chef provider -->
     <dependency>
       <groupId>org.apache.jclouds</groupId>

--- a/apis/docker/pom.xml
+++ b/apis/docker/pom.xml
@@ -79,10 +79,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.google.inject.extensions</groupId>
-      <artifactId>guice-multibindings</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.jclouds</groupId>
       <artifactId>jclouds-core</artifactId>
       <version>${project.version}</version>

--- a/apis/openstack-keystone/pom.xml
+++ b/apis/openstack-keystone/pom.xml
@@ -52,11 +52,6 @@
       <artifactId>jclouds-core</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <!-- for the extension namespaces -->
-    <dependency>
-      <groupId>com.google.inject.extensions</groupId>
-      <artifactId>guice-multibindings</artifactId>
-    </dependency>
     <dependency>
       <groupId>org.apache.jclouds</groupId>
       <artifactId>jclouds-core</artifactId>

--- a/apis/openstack-neutron/pom.xml
+++ b/apis/openstack-neutron/pom.xml
@@ -52,11 +52,6 @@
       <artifactId>jclouds-core</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <!-- for the extension namespaces -->
-    <dependency>
-      <groupId>com.google.inject.extensions</groupId>
-      <artifactId>guice-multibindings</artifactId>
-    </dependency>
     <dependency>
       <groupId>org.apache.jclouds</groupId>
       <artifactId>jclouds-core</artifactId>

--- a/apis/openstack-nova/pom.xml
+++ b/apis/openstack-nova/pom.xml
@@ -54,11 +54,6 @@
       <artifactId>openstack-neutron</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <!-- for the extension namespaces -->
-    <dependency>
-      <groupId>com.google.inject.extensions</groupId>
-      <artifactId>guice-multibindings</artifactId>
-    </dependency>
     <dependency>
       <groupId>org.apache.jclouds</groupId>
       <artifactId>jclouds-compute</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -64,7 +64,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.compendium</artifactId>
+      <artifactId>osgi.cmpn</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -38,35 +38,24 @@
 
   <dependencies>
     <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>javax.ws.rs-api</artifactId>
-      <version>2.0.1</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.inject.extensions</groupId>
-      <artifactId>guice-assistedinject</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.inject</groupId>
-      <artifactId>guice</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-security</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.squareup.okhttp</groupId>
-      <artifactId>mockwebserver</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.inject.extensions</groupId>
+      <artifactId>guice-assistedinject</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>javax.ws.rs-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
@@ -79,11 +68,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.auto.value</groupId>
-      <artifactId>auto-value</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.google.auto.service</groupId>
       <artifactId>auto-service</artifactId>
       <optional>true</optional>
@@ -92,6 +76,21 @@
       <groupId>org.gaul</groupId>
       <artifactId>modernizer-maven-annotations</artifactId>
       <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-security</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auto.value</groupId>
+      <artifactId>auto-value</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -51,16 +51,6 @@
       <artifactId>guice</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.inject</groupId>
-      <artifactId>javax.inject</artifactId>
-      <version>1</version>
-    </dependency>
-    <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>jsr250-api</artifactId>
-      <version>1.0</version>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-security</artifactId>
       <scope>test</scope>

--- a/project/bnd.bnd
+++ b/project/bnd.bnd
@@ -24,3 +24,8 @@ X-Compile-Source-JDK: \
 
 X-Compile-Target-JDK: \
     ${maven.compile.target}
+
+Import-Package: \
+    com.google.common.*;version="[27.1,30.1.0)", \
+    okio.*;version="[1.2.0,1.3)", \
+    *

--- a/project/pom.xml
+++ b/project/pom.xml
@@ -296,11 +296,6 @@
       </dependency>
       <dependency>
         <groupId>com.google.inject.extensions</groupId>
-        <artifactId>guice-multibindings</artifactId>
-        <version>${guice.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.inject.extensions</groupId>
         <artifactId>guice-assistedinject</artifactId>
         <version>${guice.version}</version>
       </dependency>

--- a/project/pom.xml
+++ b/project/pom.xml
@@ -248,8 +248,7 @@
     <logback.version>1.1.2</logback.version>
 
     <!-- OSGi dependency versions -->
-    <osgi.version>4.2.0</osgi.version>
-    <osgi.compendium.version>${osgi.version}</osgi.compendium.version>
+    <osgi.version>6.0.0</osgi.version>
 
     <!-- Test dependency versions -->
     <testng.version>6.8.21</testng.version>
@@ -369,8 +368,8 @@
       </dependency>
       <dependency>
         <groupId>org.osgi</groupId>
-        <artifactId>org.osgi.compendium</artifactId>
-        <version>${osgi.compendium.version}</version>
+        <artifactId>osgi.cmpn</artifactId>
+        <version>${osgi.version}</version>
       </dependency>
 
       <!-- Test dependencies -->

--- a/project/pom.xml
+++ b/project/pom.xml
@@ -217,36 +217,54 @@
   </developers>
 
   <properties>
+    <jdk.version>1.8</jdk.version>
+    <maven.compile.source>${jdk.version}</maven.compile.source>
+    <maven.compile.target>${jdk.version}</maven.compile.target>
+    <maven.compile.deprecation>true</maven.compile.deprecation>
 
+    <!-- Plugin versions -->
     <bnd.version>5.2.0</bnd.version>
     <maven-jar-plugin.version>3.0.1</maven-jar-plugin.version>
+    <maven-surefire-plugin.version>2.17</maven-surefire-plugin.version>
 
-    <maven.compile.source>1.8</maven.compile.source>
-    <maven.compile.target>1.8</maven.compile.target>
-    <jdk.version>1.8</jdk.version>
-    <maven.compile.deprecation>true</maven.compile.deprecation>
-    <maven.site.url.base>gitsite:git@github.com/jclouds/jclouds-maven-site.git</maven.site.url.base>
-
-    <guava.version>22.0</guava.version>
-    <!-- TODO: this has to be addressed in another feature -->
-    <guava.osgi.import>com.google.common.*;version="[22.0,30.0.0)"</guava.osgi.import>
-
-    <guice.version>4.2.3</guice.version>
+    <!-- General dependency versions -->
     <gson.version>2.8.5</gson.version>
+    <guava.version>27.1-jre</guava.version>
+    <guice.version>4.2.3</guice.version>
 
     <okhttp.version>2.2.0</okhttp.version>
-    <!-- TODO: this has to be addressed in another feature -->
-    <okio.osgi.import>okio;version="[1.2.0,1.3)"</okio.osgi.import>
-
-    <surefire.version>2.17</surefire.version>
-    <assertj-core.version>1.7.0</assertj-core.version>
-    <assertj-guava.version>1.3.0</assertj-guava.version>
     <auto-factory.version>0.1-beta1</auto-factory.version>
     <auto-service.version>1.0-rc3</auto-service.version>
     <auto-value.version>1.4.1</auto-value.version>
     <java-xmlbuilder.version>1.2</java-xmlbuilder.version>
+
+    <jetty.version>8.1.8.v20121106</jetty.version>
+
+    <modernizer-maven-annotations.version>1.8.0</modernizer-maven-annotations.version>
+
+    <!-- Log dependency versions -->
+    <log4j.version>1.2.17</log4j.version>
+    <logback.version>1.1.2</logback.version>
+
+    <!-- OSGi dependency versions -->
     <osgi.version>4.2.0</osgi.version>
     <osgi.compendium.version>${osgi.version}</osgi.compendium.version>
+
+    <!-- Test dependency versions -->
+    <testng.version>6.8.21</testng.version>
+    <xmlunit.version>1.3</xmlunit.version>
+    <assertj-core.version>1.7.0</assertj-core.version>
+    <assertj-guava.version>1.3.0</assertj-guava.version>
+
+    <!-- Mock dependency versions -->
+    <easymock.version>3.4</easymock.version>
+
+    <!-- Static analysis dependency versions -->
+    <error_prone.version>2.1.0</error_prone.version>
+    <jsr305.version>1.3.9</jsr305.version>
+
+    <maven.site.url.base>gitsite:git@github.com/jclouds/jclouds-maven-site.git</maven.site.url.base>
+
     <http.proxyHost />
     <http.proxyPort />
     <jclouds.wire.httpstream.url>https://archive.apache.org/dist/commons/logging/binaries/commons-logging-1.1.1-bin.tar.gz</jclouds.wire.httpstream.url>
@@ -260,25 +278,16 @@
 
   <dependencyManagement>
     <dependencies>
-      <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
-        <version>${guava.version}</version>
-      </dependency>
+      <!-- General dependencies -->
       <dependency>
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
         <version>${gson.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.google.code.findbugs</groupId>
-        <artifactId>jsr305</artifactId>
-        <version>1.3.9</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.inject.extensions</groupId>
-        <artifactId>guice-assistedinject</artifactId>
-        <version>${guice.version}</version>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>${guava.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.inject</groupId>
@@ -291,71 +300,11 @@
         <version>${guice.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.easymock</groupId>
-        <artifactId>easymock</artifactId>
-        <version>3.4</version>
+        <groupId>com.google.inject.extensions</groupId>
+        <artifactId>guice-assistedinject</artifactId>
+        <version>${guice.version}</version>
       </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-security</artifactId>
-        <version>8.1.8.v20121106</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-server</artifactId>
-        <version>8.1.8.v20121106</version>
-      </dependency>
-      <dependency>
-        <groupId>com.squareup.okhttp</groupId>
-        <artifactId>mockwebserver</artifactId>
-        <version>${okhttp.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.gaul</groupId>
-        <artifactId>modernizer-maven-annotations</artifactId>
-        <version>1.8.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.testng</groupId>
-        <artifactId>testng</artifactId>
-        <version>6.8.21</version>
-        <exclusions>
-          <exclusion>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>xmlunit</groupId>
-        <artifactId>xmlunit</artifactId>
-        <version>1.3</version>
-      </dependency>
-      <dependency>
-        <groupId>log4j</groupId>
-        <artifactId>log4j</artifactId>
-        <version>1.2.17</version>
-      </dependency>
-      <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-classic</artifactId>
-        <version>1.1.2</version>
-      </dependency>
-      <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-core</artifactId>
-        <version>1.1.2</version>
-      </dependency>
-      <dependency>
-        <groupId>org.assertj</groupId>
-        <artifactId>assertj-core</artifactId>
-        <version>${assertj-core.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.assertj</groupId>
-        <artifactId>assertj-guava</artifactId>
-        <version>${assertj-guava.version}</version>
-      </dependency>
+
       <dependency>
         <groupId>com.google.auto.factory</groupId>
         <artifactId>auto-factory</artifactId>
@@ -376,6 +325,42 @@
         <artifactId>java-xmlbuilder</artifactId>
         <version>${java-xmlbuilder.version}</version>
       </dependency>
+
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-security</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-server</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.gaul</groupId>
+        <artifactId>modernizer-maven-annotations</artifactId>
+        <version>${modernizer-maven-annotations.version}</version>
+      </dependency>
+
+      <!-- Log dependencies -->
+      <dependency>
+        <groupId>log4j</groupId>
+        <artifactId>log4j</artifactId>
+        <version>${log4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>${logback.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-core</artifactId>
+        <version>${logback.version}</version>
+      </dependency>
+
+      <!-- OSGi dependencies -->
       <dependency>
         <groupId>org.osgi</groupId>
         <artifactId>org.osgi.core</artifactId>
@@ -386,19 +371,62 @@
         <artifactId>org.osgi.compendium</artifactId>
         <version>${osgi.compendium.version}</version>
       </dependency>
+
+      <!-- Test dependencies -->
+      <dependency>
+        <groupId>org.testng</groupId>
+        <artifactId>testng</artifactId>
+        <version>${testng.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>xmlunit</groupId>
+        <artifactId>xmlunit</artifactId>
+        <version>${xmlunit.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <version>${assertj-core.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-guava</artifactId>
+        <version>${assertj-guava.version}</version>
+      </dependency>
+
+      <!-- Mock dependencies -->
+      <dependency>
+        <groupId>org.easymock</groupId>
+        <artifactId>easymock</artifactId>
+        <version>${easymock.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.squareup.okhttp</groupId>
+        <artifactId>mockwebserver</artifactId>
+        <version>${okhttp.version}</version>
+      </dependency>
+
+      <!-- Static analysis dependencies -->
+      <dependency>
+        <groupId>com.google.errorprone</groupId>
+        <artifactId>error_prone_annotations</artifactId>
+        <version>${error_prone.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>jsr305</artifactId>
+        <version>${jsr305.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
+
   <dependencies>
-    <dependency>
-      <groupId>com.google.errorprone</groupId>
-      <artifactId>error_prone_annotations</artifactId>
-      <version>2.1.0</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <scope>provided</scope>
-    </dependency>
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
@@ -423,6 +451,16 @@
       <groupId>org.assertj</groupId>
       <artifactId>assertj-guava</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.errorprone</groupId>
+      <artifactId>error_prone_annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 
@@ -507,7 +545,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire.version}</version>
+        <version>${maven-surefire-plugin.version}</version>
         <executions>
           <execution>
             <id>integration</id>
@@ -933,7 +971,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-surefire-report-plugin</artifactId>
-          <version>${surefire.version}</version>
+          <version>${maven-surefire-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.rat</groupId>

--- a/project/pom.xml
+++ b/project/pom.xml
@@ -1117,29 +1117,6 @@
           <configuration>
             <exceptions>
               <exception>
-                <!-- CloudSigma bundles conflict between api and providers-->
-                <conflictingDependencies>
-                  <dependency>
-                    <groupId>org.apache.jclouds.api</groupId>
-                    <artifactId>cloudsigma</artifactId>
-                    <version>${project.version}</version>
-                  </dependency>
-                  <dependency>
-                    <groupId>org.apache.jclouds.provider</groupId>
-                    <artifactId>cloudsigma-lvs</artifactId>
-                    <version>${project.version}</version>
-                  </dependency>
-                  <dependency>
-                    <groupId>org.apache.jclouds.provider</groupId>
-                    <artifactId>cloudsigma-zrh</artifactId>
-                    <version>${project.version}</version>
-                  </dependency>
-                </conflictingDependencies>
-                <packages>
-                  <package>org.jclouds.cloudsigma</package>
-                </packages>
-              </exception>
-              <exception>
                 <!-- Google App Engine Deps, some google classes are duplicated between packages -->
                 <conflictingDependencies>
                   <dependency>

--- a/project/pom.xml
+++ b/project/pom.xml
@@ -239,6 +239,7 @@
     <java-xmlbuilder.version>1.2</java-xmlbuilder.version>
 
     <jetty.version>8.1.8.v20121106</jetty.version>
+    <javax.ws.rs-api.version>2.0.1</javax.ws.rs-api.version>
 
     <modernizer-maven-annotations.version>1.8.0</modernizer-maven-annotations.version>
 
@@ -330,6 +331,11 @@
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
         <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.ws.rs</groupId>
+        <artifactId>javax.ws.rs-api</artifactId>
+        <version>${javax.ws.rs-api.version}</version>
       </dependency>
 
       <dependency>

--- a/providers/rackspace-cloudservers-uk/pom.xml
+++ b/providers/rackspace-cloudservers-uk/pom.xml
@@ -50,11 +50,6 @@
       <artifactId>openstack-nova</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <!-- for the extension namespaces -->
-    <dependency>
-      <groupId>com.google.inject.extensions</groupId>
-      <artifactId>guice-multibindings</artifactId>
-    </dependency>
     <dependency>
       <groupId>org.apache.jclouds</groupId>
       <artifactId>jclouds-core</artifactId>

--- a/providers/rackspace-cloudservers-us/pom.xml
+++ b/providers/rackspace-cloudservers-us/pom.xml
@@ -50,11 +50,6 @@
       <artifactId>openstack-nova</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <!-- for the extension namespaces -->
-    <dependency>
-      <groupId>com.google.inject.extensions</groupId>
-      <artifactId>guice-multibindings</artifactId>
-    </dependency>
     <dependency>
       <groupId>org.apache.jclouds</groupId>
       <artifactId>jclouds-core</artifactId>


### PR DESCRIPTION
- Increase version of Guava dependency from 22.0 to 27.1-jre.

Note: In an OSGi runtime, Guice version 4.2.3 expects Guava with an exact version of 27.1-jre. For now, higher versions of Guava are not possible.

- Separate version numbers from dependencies and plugins

To understand the scope of the modification work performed in the feature branch, I refer you to the notes listed in the individual commits.

**Due to an approaching release, these optional modifications will be considered in the upcoming development circle.**

https://issues.apache.org/jira/browse/JCLOUDS-1555

~~Following is a description of the purpose of the feature.~~

~~New contributors find it difficult to understand the function and intent of different plugins integrated into JClouds.~~

~~The primary goal is to simplify and streamline the overall setup.~~

~~On closer examination of the integrated plugins you will notice that,~~

~~- different plugins are used for the same or a similar goal~~
~~- the development activity of used plugins has been terminated~~
~~- modified integration requirements through Maven. The development of used plugins is progressing. Versions of the plugins integrated into JClouds are not up to date. Newer plugin versions require an adjustment to how integration into a project is done.~~

~~Basically the setup of the plugins used in the Maven project POM was done a long time ago. The project POM file of the JClouds project serves as a parent for all modules in JClouds.~~

~~The first step is to consolidate the used plugins.~~

~~The same aspects apply to the build profiles used in the project. On closer look these must be considered obsolete. A deconstruction of declared build profiles is aimed at.~~

~~In order to support newer runtime environments, for example JDK11 and above, we aim to integrate build profiles.~~

~~In the respective build profile the libraries which are no longer contained in the respective target JDK but needed in JClouds are to be integrated.~~

~~In the course of this rebuild, a property-based way of declaring the version number of dependencies and plugins will be implemented.~~