### PR TITLE
JCLOUDS-1556: Do not parse AWS HEAD response

### DIFF
--- a/apis/sts/src/main/java/org/jclouds/aws/util/AWSUtils.java
+++ b/apis/sts/src/main/java/org/jclouds/aws/util/AWSUtils.java
@@ -84,6 +84,8 @@ public class AWSUtils {
 
    public AWSError parseAWSErrorFromContent(HttpRequest request, HttpResponse response) {
       byte[] actualPayload = response.getPayload() != null ? closeClientButKeepContentStream(response) : null;
+      if (request.getMethod().equals("HEAD"))
+         return null;
       if (actualPayload == null || actualPayload.length == 0)
          return null;
       if ("text/plain".equals(response.getPayload().getContentMetadata().getContentType()))


### PR DESCRIPTION
According to RFC 2616 there cannot be a response body. Trying to parse
it results in a spurious error being logged.