### PR TITLE
JCLOUDS-1559: add Charset to Json.fromJson InputStream methods

### DIFF
--- a/core/src/main/java/org/jclouds/http/functions/ParseJson.java
+++ b/core/src/main/java/org/jclouds/http/functions/ParseJson.java
@@ -21,6 +21,7 @@ import static org.jclouds.http.HttpUtils.releasePayload;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 
 import javax.annotation.Resource;
 import javax.inject.Inject;
@@ -79,7 +80,7 @@ public class ParseJson<T> implements Function<HttpResponse, T> {
    @SuppressWarnings("unchecked")
    public <V> V apply(InputStream stream, Type type) throws IOException {
       try {
-         return (V) json.fromJson(stream, type);
+         return (V) json.fromJson(stream, StandardCharsets.UTF_8, type);
       } finally {
          if (stream != null)
             stream.close();

--- a/core/src/main/java/org/jclouds/json/Json.java
+++ b/core/src/main/java/org/jclouds/json/Json.java
@@ -18,6 +18,7 @@ package org.jclouds.json;
 
 import java.io.InputStream;
 import java.lang.reflect.Type;
+import java.nio.charset.Charset;
 
 public interface Json {
    /**
@@ -48,12 +49,12 @@ public interface Json {
     * Deserialize the generic object from json. If the object is not a generic type, use
     * {@link #fromJson(Object, Class)}
     */
-   <T> T fromJson(InputStream json, Type type);
+   <T> T fromJson(InputStream json, Charset charset, Type type);
 
    /**
     * Deserialize the object from json. If the object is a generic type, use
     * {@link #fromJson(Object, Type)}
     */
-   <T> T fromJson(InputStream json, Class<T> classOfT);
+   <T> T fromJson(InputStream json, Charset charset, Class<T> classOfT);
 
 }

--- a/core/src/main/java/org/jclouds/json/internal/GsonWrapper.java
+++ b/core/src/main/java/org/jclouds/json/internal/GsonWrapper.java
@@ -19,6 +19,7 @@ package org.jclouds.json.internal;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.Type;
+import java.nio.charset.Charset;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -51,13 +52,13 @@ public class GsonWrapper extends ForwardingObject implements Json  {
    
    @SuppressWarnings("unchecked")
    @Override
-   public <T> T fromJson(InputStream json, Type type) {
-      return (T) gson.fromJson(new InputStreamReader(json), type);
+   public <T> T fromJson(InputStream json, Charset charset, Type type) {
+      return (T) gson.fromJson(new InputStreamReader(json, charset), type);
    }
 
    @Override
-   public <T> T fromJson(InputStream json, Class<T> classOfT) {
-      return gson.fromJson(new InputStreamReader(json), classOfT);
+   public <T> T fromJson(InputStream json, Charset charset, Class<T> classOfT) {
+      return gson.fromJson(new InputStreamReader(json, charset), classOfT);
    }
 
    @Override

--- a/core/src/test/java/org/jclouds/json/JsonTest.java
+++ b/core/src/test/java/org/jclouds/json/JsonTest.java
@@ -20,7 +20,9 @@ import static com.google.common.io.BaseEncoding.base16;
 import static com.google.common.primitives.Bytes.asList;
 import static org.testng.Assert.assertEquals;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -350,6 +352,15 @@ public class JsonTest {
 
       assertEquals(json.fromJson("{\"Id\":\"1234\",\"Volumes\":null}", SerializedNamesType.class),
             SerializedNamesType.create("1234", null));
+   }
+
+   public void nonUtf8InputStream() {
+      Json json = Guice.createInjector(new GsonModule()).getInstance(Json.class);
+      String jsonValue = "{\"stringValue\":\"1234\",\"intValue\":1234}";
+      Charset ebcdicCharset = Charset.forName("IBM-1047");
+      ByteArrayInputStream inputStream = new ByteArrayInputStream(jsonValue.getBytes(ebcdicCharset));
+      assertEquals(json.fromJson(inputStream, ebcdicCharset, ObjectNoDefaultConstructor.class),
+              new ObjectNoDefaultConstructor("1234", 1234));
    }
 
    @AutoValue


### PR DESCRIPTION
My local test suite is failing due to an incorrect exception message tested by ParseSaxTest.testAddDetailsAndPropagateOkWithValidRequestResponseWithSAXParseException (running with Java 1.8)