### PR TITLE
Simplify S3 code that uses java-xml-builder

### DIFF
--- a/apis/s3/src/main/java/org/jclouds/s3/binders/BindACLToXMLPayload.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/binders/BindACLToXMLPayload.java
@@ -59,9 +59,9 @@ public class BindACLToXMLPayload implements Binder {
             S3Constants.S3_REST_API_XML_NAMESPACE);
       if (acl.getOwner() != null) {
          XMLBuilder ownerBuilder = rootBuilder.elem("Owner");
-         ownerBuilder.elem("ID").text(acl.getOwner().getId()).up();
+         ownerBuilder.elem("ID").text(acl.getOwner().getId());
          if (acl.getOwner().getDisplayName() != null) {
-            ownerBuilder.elem("DisplayName").text(acl.getOwner().getDisplayName()).up();
+            ownerBuilder.elem("DisplayName").text(acl.getOwner().getDisplayName());
          }
       }
       XMLBuilder grantsBuilder = rootBuilder.elem("AccessControlList");
@@ -74,7 +74,7 @@ public class BindACLToXMLPayload implements Binder {
             granteeBuilder.attr("xsi:type", "Group").elem("URI").text(grant.getGrantee().getIdentifier());
          } else if (grant.getGrantee() instanceof CanonicalUserGrantee) {
             CanonicalUserGrantee grantee = (CanonicalUserGrantee) grant.getGrantee();
-            granteeBuilder.attr("xsi:type", "CanonicalUser").elem("ID").text(grantee.getIdentifier()).up();
+            granteeBuilder.attr("xsi:type", "CanonicalUser").elem("ID").text(grantee.getIdentifier());
             if (grantee.getDisplayName() != null) {
                granteeBuilder.elem("DisplayName").text(grantee.getDisplayName());
             }

--- a/apis/s3/src/main/java/org/jclouds/s3/binders/BindACLToXMLPayload.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/binders/BindACLToXMLPayload.java
@@ -44,11 +44,11 @@ public class BindACLToXMLPayload implements Binder {
          String stringPayload = generateBuilder(from).asString(outputProperties);
          request.setPayload(stringPayload);
          request.getPayload().getContentMetadata().setContentType(MediaType.TEXT_XML);
+         return request;
       } catch (Exception e) {
          Throwables.propagateIfPossible(e);
          throw new RuntimeException("error transforming acl: " + from, e);
       }
-      return request;
    }
 
    protected XMLBuilder generateBuilder(AccessControlList acl) throws ParserConfigurationException,
@@ -62,8 +62,7 @@ public class BindACLToXMLPayload implements Binder {
             ownerBuilder.elem("DisplayName").text(acl.getOwner().getDisplayName());
          }
       }
-      XMLBuilder grantsBuilder = rootBuilder.elem("AccessControlList");
-      addGrants(grantsBuilder, acl.getGrants());
-      return grantsBuilder;
+      addGrants(rootBuilder.elem("AccessControlList"), acl.getGrants());
+      return rootBuilder;
    }
 }

--- a/apis/s3/src/main/java/org/jclouds/s3/binders/BindACLToXMLPayload.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/binders/BindACLToXMLPayload.java
@@ -26,14 +26,12 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.jclouds.http.HttpRequest;
 import org.jclouds.rest.Binder;
 import org.jclouds.s3.domain.AccessControlList;
-import org.jclouds.s3.domain.AccessControlList.CanonicalUserGrantee;
-import org.jclouds.s3.domain.AccessControlList.EmailAddressGrantee;
-import org.jclouds.s3.domain.AccessControlList.Grant;
-import org.jclouds.s3.domain.AccessControlList.GroupGrantee;
 import org.jclouds.s3.reference.S3Constants;
 
 import com.google.common.base.Throwables;
 import com.jamesmurty.utils.XMLBuilder;
+
+import static org.jclouds.s3.binders.BindBucketLoggingToXmlPayload.addGrants;
 
 @Singleton
 public class BindACLToXMLPayload implements Binder {
@@ -65,26 +63,7 @@ public class BindACLToXMLPayload implements Binder {
          }
       }
       XMLBuilder grantsBuilder = rootBuilder.elem("AccessControlList");
-      for (Grant grant : acl.getGrants()) {
-         XMLBuilder grantBuilder = grantsBuilder.elem("Grant");
-         XMLBuilder granteeBuilder = grantBuilder.elem("Grantee").attr("xmlns:xsi",
-               "http://www.w3.org/2001/XMLSchema-instance");
-
-         if (grant.getGrantee() instanceof GroupGrantee) {
-            granteeBuilder.attr("xsi:type", "Group").elem("URI").text(grant.getGrantee().getIdentifier());
-         } else if (grant.getGrantee() instanceof CanonicalUserGrantee) {
-            CanonicalUserGrantee grantee = (CanonicalUserGrantee) grant.getGrantee();
-            granteeBuilder.attr("xsi:type", "CanonicalUser").elem("ID").text(grantee.getIdentifier());
-            if (grantee.getDisplayName() != null) {
-               granteeBuilder.elem("DisplayName").text(grantee.getDisplayName());
-            }
-         } else if (grant.getGrantee() instanceof EmailAddressGrantee) {
-            granteeBuilder.attr("xsi:type", "AmazonCustomerByEmail").elem("EmailAddress")
-                  .text(grant.getGrantee().getIdentifier());
-         }
-         grantBuilder.elem("Permission").text(grant.getPermission());
-      }
+      addGrants(grantsBuilder, acl.getGrants());
       return grantsBuilder;
    }
-
 }

--- a/apis/s3/src/main/java/org/jclouds/s3/binders/BindACLToXMLPayload.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/binders/BindACLToXMLPayload.java
@@ -82,7 +82,7 @@ public class BindACLToXMLPayload implements Binder {
             granteeBuilder.attr("xsi:type", "AmazonCustomerByEmail").elem("EmailAddress")
                   .text(grant.getGrantee().getIdentifier());
          }
-         grantBuilder.elem("Permission").text(grant.getPermission().toString());
+         grantBuilder.elem("Permission").text(grant.getPermission());
       }
       return grantsBuilder;
    }

--- a/apis/s3/src/main/java/org/jclouds/s3/binders/BindBucketLoggingToXmlPayload.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/binders/BindBucketLoggingToXmlPayload.java
@@ -69,7 +69,7 @@ public class BindBucketLoggingToXmlPayload implements Binder {
             granteeBuilder.attr("xsi:type", "Group").elem("URI").text(grant.getGrantee().getIdentifier());
          } else if (grant.getGrantee() instanceof CanonicalUserGrantee) {
             CanonicalUserGrantee grantee = (CanonicalUserGrantee) grant.getGrantee();
-            granteeBuilder.attr("xsi:type", "CanonicalUser").elem("ID").text(grantee.getIdentifier()).up();
+            granteeBuilder.attr("xsi:type", "CanonicalUser").elem("ID").text(grantee.getIdentifier());
             if (grantee.getDisplayName() != null) {
                granteeBuilder.elem("DisplayName").text(grantee.getDisplayName());
             }

--- a/apis/s3/src/main/java/org/jclouds/s3/binders/BindBucketLoggingToXmlPayload.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/binders/BindBucketLoggingToXmlPayload.java
@@ -47,11 +47,11 @@ public class BindBucketLoggingToXmlPayload implements Binder {
          String stringPayload = generateBuilder(from).asString(outputProperties);
          request.setPayload(stringPayload);
          request.getPayload().getContentMetadata().setContentType(MediaType.TEXT_XML);
+         return request;
       } catch (Exception e) {
          Throwables.propagateIfPossible(e);
          throw new RuntimeException("error transforming bucketLogging: " + from, e);
       }
-      return request;
    }
 
    protected XMLBuilder generateBuilder(BucketLogging bucketLogging) throws ParserConfigurationException,
@@ -60,9 +60,8 @@ public class BindBucketLoggingToXmlPayload implements Binder {
             .attr("xmlns", S3Constants.S3_REST_API_XML_NAMESPACE).elem("LoggingEnabled");
       rootBuilder.elem("TargetBucket").text(bucketLogging.getTargetBucket());
       rootBuilder.elem("TargetPrefix").text(bucketLogging.getTargetPrefix());
-      XMLBuilder grantsBuilder = rootBuilder.elem("TargetGrants");
-      addGrants(grantsBuilder, bucketLogging.getTargetGrants());
-      return grantsBuilder;
+      addGrants(rootBuilder.elem("TargetGrants"), bucketLogging.getTargetGrants());
+      return rootBuilder;
    }
 
    static void addGrants(XMLBuilder grantsBuilder, Collection<Grant> grants) {

--- a/apis/s3/src/main/java/org/jclouds/s3/binders/BindBucketLoggingToXmlPayload.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/binders/BindBucketLoggingToXmlPayload.java
@@ -77,7 +77,7 @@ public class BindBucketLoggingToXmlPayload implements Binder {
             granteeBuilder.attr("xsi:type", "AmazonCustomerByEmail").elem("EmailAddress")
                   .text(grant.getGrantee().getIdentifier());
          }
-         grantBuilder.elem("Permission").text(grant.getPermission().toString());
+         grantBuilder.elem("Permission").text(grant.getPermission());
       }
       return grantsBuilder;
    }

--- a/apis/s3/src/main/java/org/jclouds/s3/binders/BindBucketLoggingToXmlPayload.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/binders/BindBucketLoggingToXmlPayload.java
@@ -16,6 +16,7 @@
  */
 package org.jclouds.s3.binders;
 
+import java.util.Collection;
 import java.util.Properties;
 
 import javax.inject.Singleton;
@@ -60,7 +61,12 @@ public class BindBucketLoggingToXmlPayload implements Binder {
       rootBuilder.elem("TargetBucket").text(bucketLogging.getTargetBucket());
       rootBuilder.elem("TargetPrefix").text(bucketLogging.getTargetPrefix());
       XMLBuilder grantsBuilder = rootBuilder.elem("TargetGrants");
-      for (Grant grant : bucketLogging.getTargetGrants()) {
+      addGrants(grantsBuilder, bucketLogging.getTargetGrants());
+      return grantsBuilder;
+   }
+
+   static void addGrants(XMLBuilder grantsBuilder, Collection<Grant> grants) {
+      for (Grant grant : grants) {
          XMLBuilder grantBuilder = grantsBuilder.elem("Grant");
          XMLBuilder granteeBuilder = grantBuilder.elem("Grantee").attr("xmlns:xsi",
                "http://www.w3.org/2001/XMLSchema-instance");
@@ -79,7 +85,6 @@ public class BindBucketLoggingToXmlPayload implements Binder {
          }
          grantBuilder.elem("Permission").text(grant.getPermission());
       }
-      return grantsBuilder;
    }
 
 }

--- a/apis/s3/src/main/java/org/jclouds/s3/binders/BindBucketLoggingToXmlPayload.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/binders/BindBucketLoggingToXmlPayload.java
@@ -56,9 +56,9 @@ public class BindBucketLoggingToXmlPayload implements Binder {
    protected XMLBuilder generateBuilder(BucketLogging bucketLogging) throws ParserConfigurationException,
          FactoryConfigurationError {
       XMLBuilder rootBuilder = XMLBuilder.create("BucketLoggingStatus")
-            .attr("xmlns", S3Constants.S3_REST_API_XML_NAMESPACE).e("LoggingEnabled");
-      rootBuilder.e("TargetBucket").t(bucketLogging.getTargetBucket());
-      rootBuilder.e("TargetPrefix").t(bucketLogging.getTargetPrefix());
+            .attr("xmlns", S3Constants.S3_REST_API_XML_NAMESPACE).elem("LoggingEnabled");
+      rootBuilder.elem("TargetBucket").text(bucketLogging.getTargetBucket());
+      rootBuilder.elem("TargetPrefix").text(bucketLogging.getTargetPrefix());
       XMLBuilder grantsBuilder = rootBuilder.elem("TargetGrants");
       for (Grant grant : bucketLogging.getTargetGrants()) {
          XMLBuilder grantBuilder = grantsBuilder.elem("Grant");

--- a/apis/s3/src/main/java/org/jclouds/s3/binders/BindIterableAsPayloadToDeleteRequest.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/binders/BindIterableAsPayloadToDeleteRequest.java
@@ -53,18 +53,15 @@ public class BindIterableAsPayloadToDeleteRequest implements Binder {
       try {
          XMLBuilder rootBuilder = XMLBuilder.create("Delete");
          for (String key : keys) {
-            XMLBuilder ownerBuilder = rootBuilder.elem("Object");
-            XMLBuilder keyBuilder = ownerBuilder.elem("Key").text(key);
+            rootBuilder.elem("Object").elem("Key").text(key);
          }
 
          Properties outputProperties = new Properties();
          outputProperties.put(OutputKeys.OMIT_XML_DECLARATION, "yes");
          content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                 rootBuilder.asString(outputProperties);
-      } catch (ParserConfigurationException pce) {
+      } catch (ParserConfigurationException | TransformerException pce) {
          throw Throwables.propagate(pce);
-      } catch (TransformerException te) {
-         throw Throwables.propagate(te);
       }
 
       Payload payload = Payloads.newStringPayload(content);

--- a/project/pom.xml
+++ b/project/pom.xml
@@ -499,7 +499,7 @@
         <configuration>
           <signature>
             <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>java17</artifactId>
+            <artifactId>java18</artifactId>
             <version>1.0</version>
           </signature>
         </configuration>


### PR DESCRIPTION
- animal sniffer should be on java18, just like `<jdk.version>`
- Only use XMLBuilder's elem() and text() methods to have similar looking code
- Remove unnecessary call to XMLBuilder's up() because the returned value is never used
- Simplify code
- Deduplicate code
- Make the code more explicit by returning the rootBuilder