### PR TITLE
Upgrade to error-prone 2.5.1

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -54,8 +54,16 @@
       <artifactId>guice-assistedinject</artifactId>
     </dependency>
     <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.ws.rs</groupId>
       <artifactId>javax.ws.rs-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/project/pom.xml
+++ b/project/pom.xml
@@ -253,7 +253,7 @@
     <easymock.version>3.4</easymock.version>
 
     <!-- Static analysis dependency versions -->
-    <error_prone.version>2.1.0</error_prone.version>
+    <error_prone.version>2.5.1</error_prone.version>
     <jsr305.version>1.3.9</jsr305.version>
 
     <http.proxyHost />
@@ -322,10 +322,21 @@
         <artifactId>jetty-server</artifactId>
         <version>${jetty.version}</version>
       </dependency>
+
+      <dependency>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+        <version>1.2</version>
+      </dependency>
       <dependency>
         <groupId>javax.ws.rs</groupId>
         <artifactId>javax.ws.rs-api</artifactId>
         <version>${javax.ws.rs-api.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <version>2.3.0</version>
       </dependency>
 
       <dependency>
@@ -668,7 +679,6 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.8.0</version>
           <configuration>
-            <compilerId>javac-with-errorprone</compilerId>
             <forceJavacCompilerUse>true</forceJavacCompilerUse>
             <encoding>${project.build.sourceEncoding}</encoding>
             <source>${maven.compile.source}</source>
@@ -683,135 +693,177 @@
               <compilerArg>-Xlint:-serial</compilerArg>
               <compilerArg>-Xlint:-unchecked</compilerArg>
 
-              <!-- on by default: warning -->
-              <compilerArg>-Xep:CannotMockFinalClass:ERROR</compilerArg>
-              <compilerArg>-Xep:ElementsCountedInLoop:ERROR</compilerArg>
-              <compilerArg>-Xep:EqualsHashCode:ERROR</compilerArg>
-              <compilerArg>-Xep:Finally:ERROR</compilerArg>
-              <compilerArg>-Xep:IncompatibleModifiers:ERROR</compilerArg>
-              <compilerArg>-Xep:JUnitAmbiguousTestClass:ERROR</compilerArg>
-              <compilerArg>-Xep:NonAtomicVolatileUpdate:OFF</compilerArg>  <!-- noisy -->
-              <compilerArg>-Xep:NonCanonicalStaticMemberImport:ERROR</compilerArg>
-              <compilerArg>-Xep:NonOverridingEquals:ERROR</compilerArg>
-              <compilerArg>-Xep:PreconditionsInvalidPlaceholder:ERROR</compilerArg>
-              <compilerArg>-Xep:ProtoFieldPreconditionsCheckNotNull:ERROR</compilerArg>
-              <compilerArg>-Xep:RequiredModifiers:ERROR</compilerArg>
-              <compilerArg>-Xep:StaticAccessedFromInstance:ERROR</compilerArg>
-              <compilerArg>-Xep:StringEquality:ERROR</compilerArg>
-              <compilerArg>-Xep:SynchronizeOnNonFinalField:ERROR</compilerArg>
-              <compilerArg>-Xep:TypeParameterUnusedInFormals:OFF</compilerArg>  <!-- noisy -->
-              <compilerArg>-Xep:UnnecessaryStaticImport:ERROR</compilerArg>
-              <compilerArg>-Xep:WaitNotInLoop:ERROR</compilerArg>
+              <compilerArg>-XDcompilePolicy=simple</compilerArg>
+              <compilerArg>-Xplugin:ErrorProne
 
-              <!-- on by default: error -->
-              <compilerArg>-Xep:ArrayEquals:ERROR</compilerArg>
-              <compilerArg>-Xep:ArrayHashCode:ERROR</compilerArg>
-              <compilerArg>-Xep:ArrayToString:ERROR</compilerArg>
-              <compilerArg>-Xep:ArrayToStringCompoundAssignment:ERROR</compilerArg>
-              <compilerArg>-Xep:ArrayToStringConcatenation:ERROR</compilerArg>
-              <compilerArg>-Xep:AsyncFunctionReturnsNull:ERROR</compilerArg>
-              <compilerArg>-Xep:BadShiftAmount:ERROR</compilerArg>
-              <compilerArg>-Xep:ChainingConstructorIgnoresParameter:ERROR</compilerArg>
-              <compilerArg>-Xep:CheckReturnValue:ERROR</compilerArg>
-              <compilerArg>-Xep:ClassName:ERROR</compilerArg>
-              <compilerArg>-Xep:ComparisonOutOfRange:ERROR</compilerArg>
-              <compilerArg>-Xep:CompileTimeConstant:ERROR</compilerArg>
-              <compilerArg>-Xep:DeadException:ERROR</compilerArg>
-              <compilerArg>-Xep:DepAnn:ERROR</compilerArg>
-              <compilerArg>-Xep:DoubleCheckedLocking:ERROR</compilerArg>
-              <compilerArg>-Xep:EqualsNaN:ERROR</compilerArg>
-              <compilerArg>-Xep:ForOverride:ERROR</compilerArg>
-              <compilerArg>-Xep:GetClassOnClass:ERROR</compilerArg>
-              <compilerArg>-Xep:GuardedByChecker:ERROR</compilerArg>
-              <compilerArg>-Xep:GuiceAssistedInjectScoping:ERROR</compilerArg>
-              <compilerArg>-Xep:HashtableContains:ERROR</compilerArg>
-              <compilerArg>-Xep:InvalidPatternSyntax:ERROR</compilerArg>
-              <compilerArg>-Xep:IsInstanceOfClass:ERROR</compilerArg>
-              <compilerArg>-Xep:JUnit3TestNotRun:ERROR</compilerArg>
-              <compilerArg>-Xep:JUnit4SetUpNotRun:ERROR</compilerArg>
-              <compilerArg>-Xep:JUnit4TearDownNotRun:ERROR</compilerArg>
-              <compilerArg>-Xep:JUnit4TestNotRun:ERROR</compilerArg>
-              <compilerArg>-Xep:LongLiteralLowerCaseSuffix:ERROR</compilerArg>
-              <compilerArg>-Xep:MisusedWeekYear:ERROR</compilerArg>
-              <compilerArg>-Xep:NarrowingCompoundAssignment:ERROR</compilerArg>
-              <compilerArg>-Xep:NonCanonicalStaticImport:ERROR</compilerArg>
-              <compilerArg>-Xep:NonFinalCompileTimeConstant:ERROR</compilerArg>
-              <compilerArg>-Xep:Overrides:ERROR</compilerArg>
-              <!-- Disabled because of internal error on Windows with 2.0.5, see https://github.com/google/error-prone/issues/432 -->
-              <!-- <compilerArg>-Xep:PackageLocation:WARNING</compilerArg> -->
-              <compilerArg>-Xep:PreconditionsCheckNotNull:ERROR</compilerArg>
-              <compilerArg>-Xep:PreconditionsCheckNotNullPrimitive:ERROR</compilerArg>
-              <compilerArg>-Xep:ProtoFieldNullComparison:ERROR</compilerArg>
-              <compilerArg>-Xep:ReturnValueIgnored:ERROR</compilerArg>
-              <compilerArg>-Xep:SelfAssignment:ERROR</compilerArg>
-              <compilerArg>-Xep:SelfEquals:ERROR</compilerArg>
-              <compilerArg>-Xep:SizeGreaterThanOrEqualsZero:ERROR</compilerArg>
-              <compilerArg>-Xep:StringBuilderInitWithChar:ERROR</compilerArg>
-              <compilerArg>-Xep:SuppressWarningsDeprecated:ERROR</compilerArg>
-              <compilerArg>-Xep:TryFailThrowable:ERROR</compilerArg>
-              <compilerArg>-Xep:UnnecessaryTypeArgument:ERROR</compilerArg>
-              <compilerArg>-Xep:UnusedAnonymousClass:ERROR</compilerArg>
+                           <!-- on by default: warning -->
+                           -Xep:AnnotateFormatMethod:OFF
+                           -Xep:AutoValueImmutableFields:OFF
+                           -Xep:AutoValueSubclassLeaked:OFF
+                           -Xep:BadImport:OFF
+                           -Xep:CacheLoaderNull:OFF
+                           -Xep:CannotMockFinalClass:ERROR
+                           -Xep:CatchAndPrintStackTrace:OFF
+                           -Xep:CloseableProvides:OFF
+                           -Xep:DefaultCharset:OFF
+                           -Xep:EmptyBlockTag:OFF
+                           -Xep:EmptyCatch:OFF
+                           -Xep:EqualsGetClass:OFF
+                           -Xep:EqualsHashCode:ERROR
+                           -Xep:FallThrough:OFF
+                           -Xep:Finally:ERROR
+                           -Xep:FloatingPointLiteralPrecision:OFF
+                           -Xep:FutureReturnValueIgnored:OFF
+                           -Xep:HidingField:OFF
+                           -Xep:ImmutableEnumChecker:OFF
+                           -Xep:IncompatibleModifiers:ERROR
+                           -Xep:InconsistentCapitalization:OFF
+                           -Xep:InlineFormatString:OFF
+                           -Xep:InputStreamSlowMultibyteRead:OFF
+                           -Xep:InvalidBlockTag:OFF
+                           -Xep:InvalidInlineTag:OFF
+                           -Xep:InvalidLink:OFF
+                           -Xep:InvalidParam:OFF
+                           -Xep:InvalidThrows:OFF
+                           -Xep:InvalidThrowsLink:OFF
+                           -Xep:JavaUtilDate:OFF
+                           -Xep:JavaLangClash:OFF
+                           -Xep:JdkObsolete:OFF
+                           -Xep:JUnitAmbiguousTestClass:ERROR
+                           -Xep:MissingOverride:OFF
+                           -Xep:MissingSummary:OFF
+                           -Xep:MixedMutabilityReturnType:OFF
+                           -Xep:ModifyCollectionInEnhancedForLoop:OFF
+                           -Xep:MutableConstantField:OFF
+                           -Xep:MutablePublicArray:OFF
+                           -Xep:NarrowingCompoundAssignment:OFF
+                           -Xep:NonAtomicVolatileUpdate:OFF
+                           -Xep:NonCanonicalStaticMemberImport:ERROR
+                           -Xep:NonCanonicalType:OFF
+                           -Xep:NonOverridingEquals:ERROR
+                           -Xep:NullOptional:OFF
+                           -Xep:ObjectEqualsForPrimitives:OFF
+                           -Xep:OverrideThrowableToString:OFF
+                           -Xep:ParameterName:OFF
+                           -Xep:PreconditionsInvalidPlaceholder:ERROR
+                           -Xep:ProtectedMembersInFinalClass:OFF
+                           -Xep:ReferenceEquality:OFF
+                           -Xep:RequiredModifiers:ERROR
+                           -Xep:ReturnFromVoid:OFF
+                           -Xep:SameNameButDifferent:OFF
+                           -Xep:StaticAssignmentInConstructor:OFF
+                           -Xep:StringEquality:ERROR
+                           -Xep:StringSplitter:OFF
+                           -Xep:SynchronizeOnNonFinalField:ERROR
+                           -Xep:ThreadLocalUsage:OFF
+                           -Xep:TypeParameterUnusedInFormals:OFF
+                           -Xep:UndefinedEquals:OFF
+                           -Xep:UnescapedEntity:OFF
+                           -Xep:UnnecessaryParentheses:OFF
+                           -Xep:UnnecessaryStaticImport:ERROR
+                           -Xep:UnusedMethod:OFF
+                           -Xep:UnusedVariable:OFF
+                           -Xep:WaitNotInLoop:ERROR
 
-              <!-- experimental: warning -->
-              <compilerArg>-Xep:AssertFalse:ERROR</compilerArg>
-              <compilerArg>-Xep:AssistedInjectAndInjectOnConstructors:ERROR</compilerArg>
-              <compilerArg>-Xep:CollectionIncompatibleType:ERROR</compilerArg>
-              <compilerArg>-Xep:GuiceInjectOnFinalField:ERROR</compilerArg>
-              <compilerArg>-Xep:MissingFail:ERROR</compilerArg>
-              <compilerArg>-Xep:NullablePrimitive:ERROR</compilerArg>
-              <compilerArg>-Xep:OverridesGuiceInjectableMethod:OFF</compilerArg>  <!-- internal error with 2.0.5 -->
-              <compilerArg>-Xep:PreconditionsErrorMessageEagerEvaluation:OFF</compilerArg>  <!-- internal error with 2.0.5 -->
-              <compilerArg>-Xep:PrimitiveArrayPassedToVarargsMethod:ERROR</compilerArg>
+                           <!-- on by default: error -->
+                           -Xep:ArrayEquals:ERROR
+                           -Xep:ArrayHashCode:ERROR
+                           -Xep:ArrayToString:ERROR
+                           -Xep:AsyncFunctionReturnsNull:ERROR
+                           -Xep:BadShiftAmount:ERROR
+                           -Xep:ChainingConstructorIgnoresParameter:ERROR
+                           -Xep:CheckReturnValue:OFF
+                           -Xep:ClassName:ERROR
+                           -Xep:ComparableType:OFF
+                           -Xep:ComparisonOutOfRange:ERROR
+                           -Xep:CompileTimeConstant:ERROR
+                           -Xep:DeadException:ERROR
+                           -Xep:DepAnn:ERROR
+                           -Xep:DoubleCheckedLocking:ERROR
+                           -Xep:EqualsNaN:ERROR
+                           -Xep:ForOverride:ERROR
+                           -Xep:GetClassOnAnnotation:OFF
+                           -Xep:GetClassOnClass:ERROR
+                           -Xep:GuiceAssistedInjectScoping:ERROR
+                           -Xep:HashtableContains:ERROR
+                           -Xep:InjectOnMemberAndConstructor:OFF
+                           -Xep:InvalidPatternSyntax:ERROR
+                           -Xep:IsInstanceOfClass:ERROR
+                           -Xep:JUnit3TestNotRun:ERROR
+                           -Xep:JUnit4SetUpNotRun:ERROR
+                           -Xep:JUnit4TearDownNotRun:ERROR
+                           -Xep:JUnit4TestNotRun:ERROR
+                           -Xep:LongLiteralLowerCaseSuffix:ERROR
+                           -Xep:MisusedWeekYear:ERROR
+                           -Xep:NonCanonicalStaticImport:ERROR
+                           -Xep:NonFinalCompileTimeConstant:ERROR
+                           -Xep:Overrides:ERROR
+                           -Xep:ProtoFieldNullComparison:ERROR
+                           -Xep:ProvidesMethodOutsideOfModule:OFF
+                           -Xep:ReturnValueIgnored:ERROR
+                           -Xep:SelfAssignment:ERROR
+                           -Xep:SelfEquals:ERROR
+                           -Xep:SizeGreaterThanOrEqualsZero:ERROR
+                           -Xep:StringBuilderInitWithChar:ERROR
+                           -Xep:SuppressWarningsDeprecated:ERROR
+                           -Xep:TryFailThrowable:ERROR
+                           -Xep:UnnecessaryTypeArgument:ERROR
+                           -Xep:UnusedAnonymousClass:ERROR
 
-              <!-- experimental: not a problem -->
-              <compilerArg>-Xep:FallthroughSuppression</compilerArg>
+                           <!-- experimental: warning -->
+                           -Xep:AssertFalse:ERROR
+                           -Xep:AssistedInjectAndInjectOnConstructors:ERROR
+                           -Xep:CollectionIncompatibleType:ERROR
+                           -Xep:GuiceInjectOnFinalField:ERROR
+                           -Xep:MissingFail:ERROR
+                           -Xep:NullablePrimitive:ERROR
+                           -Xep:OverridesGuiceInjectableMethod:OFF  <!-- internal error with 2.0.5 -->
+                           -Xep:PrimitiveArrayPassedToVarargsMethod:ERROR
+                           -Xep:UnnecessaryAnonymousClass:OFF
 
-              <!-- experimental: error -->
-              <compilerArg>-Xep:ArraysAsListPrimitiveArray:ERROR</compilerArg>
-              <compilerArg>-Xep:AssistedInjectAndInjectOnSameConstructor:ERROR</compilerArg>
-              <compilerArg>-Xep:ClassCanBeStatic:ERROR</compilerArg>
-              <compilerArg>-Xep:DivZero:ERROR</compilerArg>
-              <compilerArg>-Xep:EmptyIf:ERROR</compilerArg>
-              <compilerArg>-Xep:GuardedByValidator:ERROR</compilerArg>
-              <compilerArg>-Xep:GuiceAssistedParameters:ERROR</compilerArg>
-              <compilerArg>-Xep:InjectInvalidTargetingOnScopingAnnotation:ERROR</compilerArg>
-              <compilerArg>-Xep:InjectMoreThanOneQualifier:OFF</compilerArg>  <!-- noisy -->
-              <compilerArg>-Xep:InjectMoreThanOneScopeAnnotationOnClass:ERROR</compilerArg>
-              <compilerArg>-Xep:InjectScopeAnnotationOnInterfaceOrAbstractClass:ERROR</compilerArg>
-              <compilerArg>-Xep:InjectScopeOrQualifierAnnotationRetention:ERROR</compilerArg>
-              <compilerArg>-Xep:InjectedConstructorAnnotations:ERROR</compilerArg>
-              <compilerArg>-Xep:JMockTestWithoutRunWithOrRuleAnnotation:ERROR</compilerArg>
-              <compilerArg>-Xep:JavaxInjectOnAbstractMethod:ERROR</compilerArg>
-              <compilerArg>-Xep:JavaxInjectOnFinalField:ERROR</compilerArg>
-              <compilerArg>-Xep:LockMethodChecker:ERROR</compilerArg>
-              <compilerArg>-Xep:MalformedFormatString:ERROR</compilerArg>
-              <compilerArg>-Xep:MissingCasesInEnumSwitch:OFF</compilerArg>  <!-- noisy -->
-              <compilerArg>-Xep:ModifyingCollectionWithItself:ERROR</compilerArg>
-              <compilerArg>-Xep:MoreThanOneInjectableConstructor:OFF</compilerArg>  <!-- internal error with 2.0.5 -->
-              <compilerArg>-Xep:NoAllocation:ERROR</compilerArg>
-              <compilerArg>-Xep:NonRuntimeAnnotation:ERROR</compilerArg>
-              <compilerArg>-Xep:NumericEquality:ERROR</compilerArg>
-              <compilerArg>-Xep:OverlappingQualifierAndScopeAnnotation:ERROR</compilerArg>
-              <compilerArg>-Xep:OverridesJavaxInjectableMethod:OFF</compilerArg>  <!-- internal error with 2.0.5 -->
-              <compilerArg>-Xep:ParameterPackage:OFF</compilerArg>  <!-- internal error with 2.0.5 -->
-              <compilerArg>-Xep:ProtoStringFieldReferenceEquality:ERROR</compilerArg>
-              <compilerArg>-Xep:SelfEquality:ERROR</compilerArg>
-              <compilerArg>-Xep:UnlockMethod:ERROR</compilerArg>
-              <compilerArg>-Xep:WildcardImport:ERROR</compilerArg>
+                           <!-- experimental: error -->
+                           -Xep:ArraysAsListPrimitiveArray:ERROR
+                           -Xep:AssistedInjectAndInjectOnSameConstructor:ERROR
+                           -Xep:ClassCanBeStatic:ERROR
+                           -Xep:DivZero:ERROR
+                           -Xep:EmptyIf:ERROR
+                           -Xep:GuiceAssistedParameters:ERROR
+                           -Xep:InjectInvalidTargetingOnScopingAnnotation:ERROR
+                           -Xep:InjectMoreThanOneQualifier:OFF  <!-- noisy -->
+                           -Xep:InjectMoreThanOneScopeAnnotationOnClass:ERROR
+                           -Xep:InjectScopeAnnotationOnInterfaceOrAbstractClass:ERROR
+                           -Xep:InjectScopeOrQualifierAnnotationRetention:ERROR
+                           -Xep:InjectedConstructorAnnotations:ERROR
+                           -Xep:JMockTestWithoutRunWithOrRuleAnnotation:ERROR
+                           -Xep:JavaxInjectOnAbstractMethod:ERROR
+                           -Xep:JavaxInjectOnFinalField:ERROR
+                           -Xep:LockMethodChecker:ERROR
+                           -Xep:MissingCasesInEnumSwitch:OFF  <!-- noisy -->
+                           -Xep:ModifyingCollectionWithItself:ERROR
+                           -Xep:MoreThanOneInjectableConstructor:OFF  <!-- internal error with 2.0.5 -->
+                           -Xep:NoAllocation:ERROR
+                           -Xep:NonRuntimeAnnotation:ERROR
+                           -Xep:NumericEquality:ERROR
+                           -Xep:OverlappingQualifierAndScopeAnnotation:ERROR
+                           -Xep:OverridesJavaxInjectableMethod:OFF  <!-- internal error with 2.0.5 -->
+                           -Xep:ProtoStringFieldReferenceEquality:ERROR
+                           -Xep:UnlockMethod:ERROR
+                           -Xep:WildcardImport:ERROR
+              </compilerArg>
             </compilerArgs>
+            <annotationProcessorPaths>
+              <path>
+                <groupId>com.google.auto.value</groupId>
+                <artifactId>auto-value</artifactId>
+                <version>${auto-value.version}</version>
+              </path>
+              <path>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_core</artifactId>
+                <version>${error_prone.version}</version>
+              </path>
+            </annotationProcessorPaths>
           </configuration>
-          <dependencies>
-            <dependency>
-              <groupId>org.codehaus.plexus</groupId>
-              <artifactId>plexus-compiler-javac-errorprone</artifactId>
-              <version>2.6</version>
-            </dependency>
-            <dependency>
-              <groupId>com.google.errorprone</groupId>
-              <artifactId>error_prone_core</artifactId>
-              <version>2.0.5</version>
-            </dependency>
-          </dependencies>
         </plugin>
         <plugin>
           <artifactId>maven-archetype-plugin</artifactId>


### PR DESCRIPTION
This addresses issues seen with more recent Java and Maven versions.
Enabled by requiring Java 8.  Also suppress several new warnings and
remove stale ones.  This commit also adds the missing jaxb and xml
dependencies needed with newer Java versions.