### PR TITLE
JCLOUDS-1580 - Add support for lowercase metadata headers

### DIFF
--- a/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/functions/EntriesWithoutMetaPrefix.java
+++ b/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/functions/EntriesWithoutMetaPrefix.java
@@ -38,7 +38,7 @@ public enum EntriesWithoutMetaPrefix implements Function<Multimap<String, String
    public Map<String, String> apply(Multimap<String, String> arg0) {
       ImmutableMap.Builder<String, String> metadata = ImmutableMap.builder();
       for (Entry<String, String> header : arg0.entries()) {
-         int index = header.getKey().indexOf("-Meta-");
+         int index = header.getKey().toLowerCase().indexOf("-meta-");
          if (index != -1) {
             metadata.put(header.getKey().substring(index + 6), header.getValue());
          }

--- a/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/features/ObjectApiMockTest.java
+++ b/apis/openstack-swift/src/test/java/org/jclouds/openstack/swift/v1/features/ObjectApiMockTest.java
@@ -333,7 +333,7 @@ public class ObjectApiMockTest extends BaseOpenStackMockTest<SwiftApi> {
       server.enqueue(addCommonHeaders(objectResponse()
             // note silly casing
             .addHeader(OBJECT_METADATA_PREFIX + "Apiname", "swift")
-            .addHeader(OBJECT_METADATA_PREFIX + "Apiversion", "v1.1")));
+            .addHeader(OBJECT_METADATA_PREFIX.toLowerCase() + "apiversion", "v1.1")));
 
       try {
          SwiftApi api = api(server.url("/").toString(), "openstack-swift");
@@ -346,6 +346,7 @@ public class ObjectApiMockTest extends BaseOpenStackMockTest<SwiftApi> {
                object.getPayload().getContentMetadata().getContentMD5AsHashCode().asBytes());
 
          assertEquals(object.getLastModified(), dates.rfc822DateParse("Fri, 12 Jun 2010 13:40:18 GMT"));
+         assertEquals(object.getMetadata().size(), 2);
          for (Entry<String, String> entry : object.getMetadata().entrySet()) {
             assertEquals(object.getMetadata().get(entry.getKey().toLowerCase()), entry.getValue());
          }


### PR DESCRIPTION
The issue happens if a cloud provider returns lowercase metadata headers, for example: "x-object-meta-apiversion" instead of "X-Object-Meta-ApiVersion"

In that case, BlobStore.blobMetadata(CONTAINER, PATH).getUserMetadata()
incorrectly returns an empty map.

This happens because the code is looking for the exact String "-Meta-" (case-sensitive).

This checkin allows to handle metadata headers of any case, and also adds a unit test for that situation.