### PR TITLE
Re-optimize LocalBlobStore.getBlob with ranges

### DIFF
--- a/blobstore/src/main/java/org/jclouds/blobstore/config/LocalBlobStore.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/config/LocalBlobStore.java
@@ -682,10 +682,13 @@ public final class LocalBlobStore implements BlobStore {
 
             // Try to convert payload to ByteSource, otherwise wrap it.
             ByteSource byteSource;
-            try {
-               byteSource = (ByteSource) blob.getPayload().getRawContent();
-            } catch (ClassCastException cce) {
-               // This should not happen; both FilesystemStorageStrategyImpl and TransientStorageStrategy return ByteSource
+            Object object = blob.getPayload().getRawContent();
+            if (object instanceof ByteSource) {
+               byteSource = (ByteSource) object;
+            } else if (object instanceof byte[]) {
+               byteSource = ByteSource.wrap((byte[]) object);
+            } else {
+               // This should not happen.
                try {
                   byteSource = ByteSource.wrap(ByteStreams2.toByteArrayAndClose(blob.getPayload().openStream()));
                } catch (IOException e) {


### PR DESCRIPTION
This fixes a memory regression from
8de7b696e13f7131b3ea4a77b10f5cfd139dd712 where the transient `BlobStore`
changed from a `ByteSource` to a `byte[]`.