### PR TITLE
JCLOUDS-1581: Make CORS maxAgeSeconds optional

### DIFF
--- a/providers/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/domain/Bucket.java
+++ b/providers/google-cloud-storage/src/main/java/org/jclouds/googlecloudstorage/domain/Bucket.java
@@ -44,7 +44,7 @@ public abstract class Bucket {
 
       public abstract List<String> responseHeader();
 
-      public abstract Integer maxAgeSeconds();
+      @Nullable public abstract Integer maxAgeSeconds();
 
       @SerializedNames({ "origin", "method", "responseHeader", "maxAgeSeconds" })
       public static Cors create(List<String> origin, List<String> method, List<String> responseHeader,


### PR DESCRIPTION
This field is not required:

https://cloud.google.com/storage/docs/cross-origin#cors-elements