### PR TITLE
Add missing javax dependencies for modern Java

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -58,6 +58,14 @@
       <artifactId>javax.ws.rs-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.core</artifactId>
       <scope>provided</scope>

--- a/project/pom.xml
+++ b/project/pom.xml
@@ -322,6 +322,18 @@
       </dependency>
 
       <dependency>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+        <version>1.2</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-impl</artifactId>
+        <version>2.3.3</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.gaul</groupId>
         <artifactId>modernizer-maven-annotations</artifactId>
         <version>${modernizer-maven-annotations.version}</version>


### PR DESCRIPTION
Java 9 modularization removed these.