### PR TITLE
Upgrade to duplicate-finder-maven-plugin 1.5.0

### DIFF
--- a/project/pom.xml
+++ b/project/pom.xml
@@ -798,7 +798,7 @@
         <plugin>
           <groupId>org.basepom.maven</groupId>
           <artifactId>duplicate-finder-maven-plugin</artifactId>
-          <version>1.1.2</version>
+          <version>1.5.0</version>
           <configuration>
             <exceptions>
               <exception>


### PR DESCRIPTION
Notably this fixes an issue with duplicate module-version files in
JAXB.  Release notes:

https://github.com/basepom/duplicate-finder-maven-plugin/releases