### PR TITLE
JCLOUDS-1586: Upgrade to Guice 5.0.1

### DIFF
--- a/project/pom.xml
+++ b/project/pom.xml
@@ -223,7 +223,7 @@
     <!-- General dependency versions -->
     <gson.version>2.8.5</gson.version>
     <guava.version>27.1-jre</guava.version>
-    <guice.version>4.2.3</guice.version>
+    <guice.version>5.0.1</guice.version>
 
     <okhttp.version>3.14.9</okhttp.version>
     <auto-factory.version>0.1-beta1</auto-factory.version>


### PR DESCRIPTION
Guice 4.2.3 makes illegal reflective accesses that Java 17 does not
allow.  References google/guice#1133.  Release notes:

https://github.com/google/guice/wiki/Guice501