### PR TITLE
Bump google gson to 2.8.9 due to detected vulnerability

### DIFF
--- a/project/pom.xml
+++ b/project/pom.xml
@@ -221,7 +221,7 @@
     <maven-surefire-plugin.version>2.17</maven-surefire-plugin.version>
 
     <!-- General dependency versions -->
-    <gson.version>2.8.5</gson.version>
+    <gson.version>2.8.9</gson.version>
     <guava.version>27.1-jre</guava.version>
     <guice.version>4.2.3</guice.version>
 


### PR DESCRIPTION
Snyk identifies now previos version of gson as vulnerable. This updates gson to the fixed version
skyn report: https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLECODEGSON-1730327
gson PR: https://github.com/google/gson/pull/1991