### PR TITLE
JCLOUDS-1589: Upgrade to log4j 2.16.0

### DIFF
--- a/apis/atmos/pom.xml
+++ b/apis/atmos/pom.xml
@@ -59,8 +59,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/apis/cloudwatch/pom.xml
+++ b/apis/cloudwatch/pom.xml
@@ -59,8 +59,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/apis/s3/pom.xml
+++ b/apis/s3/pom.xml
@@ -79,8 +79,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/apis/sts/pom.xml
+++ b/apis/sts/pom.xml
@@ -59,8 +59,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/drivers/log4j/pom.xml
+++ b/drivers/log4j/pom.xml
@@ -44,8 +44,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/drivers/log4j/src/main/java/org/jclouds/logging/log4j/Log4JLogger.java
+++ b/drivers/log4j/src/main/java/org/jclouds/logging/log4j/Log4JLogger.java
@@ -16,9 +16,6 @@
  */
 package org.jclouds.logging.log4j;
 
-import static org.apache.log4j.Level.ERROR;
-import static org.apache.log4j.Level.WARN;
-
 import org.jclouds.logging.BaseLogger;
 import org.jclouds.logging.Logger;
 
@@ -26,17 +23,17 @@ import org.jclouds.logging.Logger;
  * {@link org.apache.log4j.Logger} implementation of {@link Logger}.
  */
 public class Log4JLogger extends BaseLogger {
-    private final org.apache.log4j.Logger logger;
+    private final org.apache.logging.log4j.Logger logger;
     private final String category;
 
     public static class Log4JLoggerFactory implements LoggerFactory {
 	public Logger getLogger(String category) {
-	    return new Log4JLogger(category, org.apache.log4j.Logger
+	    return new Log4JLogger(category, org.apache.logging.log4j.LogManager
 		    .getLogger(category));
 	}
     }
 
-    public Log4JLogger(String category, org.apache.log4j.Logger logger) {
+    public Log4JLogger(String category, org.apache.logging.log4j.Logger logger) {
 	this.category = category;
 	this.logger = logger;
     }
@@ -79,7 +76,7 @@ public class Log4JLogger extends BaseLogger {
     }
 
     public boolean isWarnEnabled() {
-	return logger.isEnabledFor(WARN);
+	return logger.isWarnEnabled();
     }
 
     @Override
@@ -93,7 +90,7 @@ public class Log4JLogger extends BaseLogger {
     }
 
     public boolean isErrorEnabled() {
-	return logger.isEnabledFor(ERROR);
+	return logger.isErrorEnabled();
     }
 
     public String getCategory() {

--- a/loadbalancer/pom.xml
+++ b/loadbalancer/pom.xml
@@ -61,8 +61,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/project/pom.xml
+++ b/project/pom.xml
@@ -236,7 +236,7 @@
     <modernizer-maven-annotations.version>1.8.0</modernizer-maven-annotations.version>
 
     <!-- Log dependency versions -->
-    <log4j.version>1.2.17</log4j.version>
+    <log4j.version>2.16.0</log4j.version>
     <logback.version>1.1.2</logback.version>
 
     <!-- OSGi dependency versions -->
@@ -336,8 +336,8 @@
 
       <!-- Log dependencies -->
       <dependency>
-        <groupId>log4j</groupId>
-        <artifactId>log4j</artifactId>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-core</artifactId>
         <version>${log4j.version}</version>
       </dependency>
       <dependency>

--- a/providers/b2/pom.xml
+++ b/providers/b2/pom.xml
@@ -66,8 +66,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/skeletons/standalone-compute/pom.xml
+++ b/skeletons/standalone-compute/pom.xml
@@ -59,8 +59,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This addresses a critical CVE:

https://logging.apache.org/log4j/2.x/security.html