### PR TITLE
JCLOUDS-1587 - S3 Blobstore: Support Bucket Configuration Options - Versioning, Lifecycle, Encryption

### DIFF
--- a/apis/s3/src/main/java/org/jclouds/s3/S3Client.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/S3Client.java
@@ -659,13 +659,12 @@ public interface S3Client extends Closeable {
        BindAsHostPrefixIfConfigured.class) @ParamValidators(BucketNameValidator.class) String bucketName,
                                     BucketConfigOptions... options);
 
-   @Named("GetBucketConfiguration")
-   @GET
+   @Named("DeleteBucketConfiguration")
+   @DELETE
    @Path("/")
    @ResponseParser(BucketConfigurationHandler.class)
-   String getBucketConfiguration(@Bucket @EndpointParam(parser = AssignCorrectHostnameForBucket.class) @BinderParam(
-       BindAsHostPrefixIfConfigured.class) @ParamValidators(BucketNameValidator.class) String bucketName, @BinderParam(BindS3ObjectMetadataToRequest.class)
-       S3Object object, BucketConfigOptions... options);
+   String deleteBucketConfiguration(@Bucket @EndpointParam(parser = AssignCorrectHostnameForBucket.class) @BinderParam(
+       BindAsHostPrefixIfConfigured.class) @ParamValidators(BucketNameValidator.class) String bucketName, BucketConfigOptions... options);
 
    @Named("PutBucketConfiguration")
    @PUT

--- a/apis/s3/src/main/java/org/jclouds/s3/S3Client.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/S3Client.java
@@ -35,9 +35,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
-import com.google.common.annotations.Beta;
-import com.google.inject.Provides;
-
 import org.jclouds.Fallbacks.VoidOnNotFoundOr404;
 import org.jclouds.blobstore.BlobStoreFallbacks.FalseOnContainerNotFound;
 import org.jclouds.blobstore.BlobStoreFallbacks.FalseOnKeyNotFound;
@@ -114,6 +111,9 @@ import org.jclouds.s3.xml.LocationConstraintHandler;
 import org.jclouds.s3.xml.PartIdsFromHttpResponse;
 import org.jclouds.s3.xml.PartIdsFromHttpResponseFull;
 import org.jclouds.s3.xml.PayerHandler;
+
+import com.google.common.annotations.Beta;
+import com.google.inject.Provides;
 
 /**
  * Provides access to S3 via their REST API.
@@ -264,7 +264,7 @@ public interface S3Client extends Closeable {
     * @return ETag of the content uploaded
     * @throws org.jclouds.http.HttpResponseException
     *            if the conditions requested set are not satisfied by the object on the server.
-    * @see CannedAccessPolicy#PRIVATE
+    * @see org.jclouds.s3.domain.CannedAccessPolicy#PRIVATE
     */
    @Named("PutObject")
    @PUT
@@ -358,8 +358,9 @@ public interface S3Client extends Closeable {
    @Path("/")
    @XMLResponseParser(ListVersionHandler.class)
    ListVersionsResponse listVersions(@Bucket @EndpointParam(parser = AssignCorrectHostnameForBucket.class) @BinderParam(
-       BindAsHostPrefixIfConfigured.class) @ParamValidators(BucketNameValidator.class) String bucketName,
-                                           ListBucketOptions... options);
+         BindAsHostPrefixIfConfigured.class) @ParamValidators(BucketNameValidator.class) String bucketName,
+         ListBucketOptions... options);
+
    /**
     * Returns a list of all of the buckets owned by the authenticated sender of the request.
     * 
@@ -379,17 +380,17 @@ public interface S3Client extends Closeable {
     * in Amazon S3.
     * <p/>
     * When copying an object, you can preserve all metadata (default) or
-    * {@link CopyObjectOptions#overrideMetadataWith(Map)} specify new
+    * {@link CopyObjectOptions#overrideMetadataWith(java.util.Map)} specify new
     * metadata}. However, the ACL is not preserved and is set to private for the user making the
     * request. To override the default ACL setting,
-    * {@link CopyObjectOptions#overrideAcl(CannedAccessPolicy) specify a
+    * {@link CopyObjectOptions#overrideAcl(org.jclouds.s3.domain.CannedAccessPolicy) specify a
     * new ACL} when generating a copy request.
     * 
     * @return metadata populated with lastModified and eTag of the new object
     * @throws org.jclouds.http.HttpResponseException
     *            if the conditions requested set are not satisfied by the object on the server.
     * @see CopyObjectOptions
-    * @see CannedAccessPolicy
+    * @see org.jclouds.s3.domain.CannedAccessPolicy
     */
    @Named("PutObject")
    @PUT
@@ -656,24 +657,24 @@ public interface S3Client extends Closeable {
    @Path("/")
    @ResponseParser(BucketConfigurationHandler.class)
    String getBucketConfiguration(@Bucket @EndpointParam(parser = AssignCorrectHostnameForBucket.class) @BinderParam(
-       BindAsHostPrefixIfConfigured.class) @ParamValidators(BucketNameValidator.class) String bucketName,
-                                    BucketConfigOptions... options);
+         BindAsHostPrefixIfConfigured.class) @ParamValidators(BucketNameValidator.class) String bucketName,
+         BucketConfigOptions... options);
 
    @Named("DeleteBucketConfiguration")
    @DELETE
    @Path("/")
    @ResponseParser(BucketConfigurationHandler.class)
    String deleteBucketConfiguration(@Bucket @EndpointParam(parser = AssignCorrectHostnameForBucket.class) @BinderParam(
-       BindAsHostPrefixIfConfigured.class) @ParamValidators(BucketNameValidator.class) String bucketName, BucketConfigOptions... options);
+         BindAsHostPrefixIfConfigured.class) @ParamValidators(BucketNameValidator.class) String bucketName, BucketConfigOptions... options);
 
    @Named("PutBucketConfiguration")
    @PUT
    @Path("/")
    @ResponseParser(BucketConfigurationHandler.class)
    String putBucketConfiguration(@Bucket @EndpointParam(parser = AssignCorrectHostnameForBucket.class) @BinderParam(
-       BindAsHostPrefixIfConfigured.class) @ParamValidators(BucketNameValidator.class) String bucketName,
-                    @BinderParam(BindS3ObjectMetadataToRequest.class)
-                        S3Object object, BucketConfigOptions... options);
+         BindAsHostPrefixIfConfigured.class) @ParamValidators(BucketNameValidator.class) String bucketName,
+         @BinderParam(BindS3ObjectMetadataToRequest.class)
+         S3Object object, BucketConfigOptions... options);
 
    /**
     * This operation initiates a multipart upload and returns an upload ID. This upload ID is used

--- a/apis/s3/src/main/java/org/jclouds/s3/blobstore/S3BlobStore.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/blobstore/S3BlobStore.java
@@ -29,13 +29,6 @@ import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
-import com.google.common.base.Supplier;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
-
 import org.jclouds.blobstore.BlobStoreContext;
 import org.jclouds.blobstore.ContainerNotFoundException;
 import org.jclouds.blobstore.domain.Blob;
@@ -81,6 +74,13 @@ import org.jclouds.s3.options.PutBucketOptions;
 import org.jclouds.s3.options.PutObjectOptions;
 import org.jclouds.s3.util.S3Utils;
 
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+
 @Singleton
 public class S3BlobStore extends BaseBlobStore {
    private final S3Client sync;
@@ -96,12 +96,12 @@ public class S3BlobStore extends BaseBlobStore {
 
    @Inject
    protected S3BlobStore(BlobStoreContext context, BlobUtils blobUtils, Supplier<Location> defaultLocation,
-                         @Memoized Supplier<Set<? extends Location>> locations, PayloadSlicer slicer, S3Client sync,
-                         Function<Set<BucketMetadata>, PageSet<? extends StorageMetadata>> convertBucketsToStorageMetadata,
-                         ContainerToBucketListOptions container2BucketListOptions, BucketToResourceList bucket2ResourceList,
-                         ObjectToBlob object2Blob, BlobToHttpGetOptions blob2ObjectGetOptions, BlobToObject blob2Object,
-                         BlobToObjectMetadata blob2ObjectMetadata,
-                         ObjectToBlobMetadata object2BlobMd, Provider<FetchBlobMetadata> fetchBlobMetadataProvider) {
+            @Memoized Supplier<Set<? extends Location>> locations, PayloadSlicer slicer, S3Client sync,
+            Function<Set<BucketMetadata>, PageSet<? extends StorageMetadata>> convertBucketsToStorageMetadata,
+            ContainerToBucketListOptions container2BucketListOptions, BucketToResourceList bucket2ResourceList,
+            ObjectToBlob object2Blob, BlobToHttpGetOptions blob2ObjectGetOptions, BlobToObject blob2Object,
+            BlobToObjectMetadata blob2ObjectMetadata,
+            ObjectToBlobMetadata object2BlobMd, Provider<FetchBlobMetadata> fetchBlobMetadataProvider) {
       super(context, blobUtils, defaultLocation, locations, slicer);
       this.blob2ObjectGetOptions = checkNotNull(blob2ObjectGetOptions, "blob2ObjectGetOptions");
       this.sync = checkNotNull(sync, "sync");
@@ -135,13 +135,11 @@ public class S3BlobStore extends BaseBlobStore {
    }
 
    public String getBucketConfiguration(String bucketName, BucketConfigOptions httpOptions ) {
-      String response = sync.getBucketConfiguration(bucketName, httpOptions);
-      return response;
+      return sync.getBucketConfiguration(bucketName, httpOptions);
    }
 
    public String deleteBucketConfiguration(String bucketName, BucketConfigOptions httpOptions ) {
-      String response = sync.deleteBucketConfiguration(bucketName, httpOptions);
-      return response;
+      return sync.deleteBucketConfiguration(bucketName, httpOptions);
    }
 
    public String putBucketConfiguration(String container, Blob blob, BucketConfigOptions httpOptions) {

--- a/apis/s3/src/main/java/org/jclouds/s3/blobstore/S3BlobStore.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/blobstore/S3BlobStore.java
@@ -192,7 +192,7 @@ public class S3BlobStore extends BaseBlobStore {
       PageSet<? extends StorageMetadata> list = null;
       if (httpOptions.getVersions()){
          list = bucket2ResourceList.apply(sync.listVersions(container, httpOptions));
-      }else{
+      } else {
          list = bucket2ResourceList.apply(sync.listBucket(container, httpOptions));
       }
       return options.isDetailed() ? fetchBlobMetadataProvider.get().setContainerName(container).apply(list) : list;

--- a/apis/s3/src/main/java/org/jclouds/s3/blobstore/S3BlobStore.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/blobstore/S3BlobStore.java
@@ -139,8 +139,8 @@ public class S3BlobStore extends BaseBlobStore {
       return response;
    }
 
-   public String getBucketConfiguration(String bucketName, Blob blob, BucketConfigOptions httpOptions ) {
-      String response = sync.getBucketConfiguration(bucketName, blob2Object.apply(blob), httpOptions);
+   public String deleteBucketConfiguration(String bucketName, BucketConfigOptions httpOptions ) {
+      String response = sync.deleteBucketConfiguration(bucketName, httpOptions);
       return response;
    }
 

--- a/apis/s3/src/main/java/org/jclouds/s3/blobstore/functions/BlobToObjectMetadata.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/blobstore/functions/BlobToObjectMetadata.java
@@ -45,6 +45,7 @@ public class BlobToObjectMetadata implements Function<BlobMetadata, MutableObjec
       to.setKey(from.getName());
       to.setBucket(bucket);
       to.setLastModified(from.getLastModified());
+      to.setVersionId(from.getVersionId());
       if (from.getUserMetadata() != null) {
          for (Entry<String, String> entry : from.getUserMetadata().entrySet())
             to.getUserMetadata().put(entry.getKey().toLowerCase(), entry.getValue());

--- a/apis/s3/src/main/java/org/jclouds/s3/blobstore/functions/BucketToResourceList.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/blobstore/functions/BucketToResourceList.java
@@ -21,14 +21,14 @@ import java.util.SortedSet;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Sets;
-
 import org.jclouds.blobstore.domain.PageSet;
 import org.jclouds.blobstore.domain.StorageMetadata;
 import org.jclouds.blobstore.domain.internal.PageSetImpl;
 import org.jclouds.s3.domain.ListBucketResponse;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
 import org.jclouds.s3.domain.ListVersionsResponse;
 
 @Singleton
@@ -46,7 +46,7 @@ public class BucketToResourceList implements
 
    @Inject
    public BucketToResourceList(ObjectToBlobMetadata object2blobMd,
-                               CommonPrefixesToResourceMetadata prefix2ResourceMd) {
+            CommonPrefixesToResourceMetadata prefix2ResourceMd) {
       this.object2blobMd = object2blobMd;
       this.prefix2ResourceMd = prefix2ResourceMd;
    }
@@ -65,7 +65,7 @@ public class BucketToResourceList implements
    public PageSet<? extends StorageMetadata> apply(ListVersionsResponse from) {
       // S3 lists keys in sorted order; use sorted set to order relative paths correctly
       SortedSet<StorageMetadata> contents = Sets.<StorageMetadata> newTreeSet(Iterables.transform(from,
-          object2blobMd));
+               object2blobMd));
 
       for (String prefix : from.getCommonPrefixes()) {
          contents.add(prefix2ResourceMd.apply(prefix));

--- a/apis/s3/src/main/java/org/jclouds/s3/blobstore/functions/ContainerToBucketListOptions.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/blobstore/functions/ContainerToBucketListOptions.java
@@ -64,7 +64,7 @@ public class ContainerToBucketListOptions implements
          httpOptions.maxResults(from.getMaxResults());
       }
       if (from.isVersions()) {
-            httpOptions.versions(from.isVersions());
+         httpOptions.versions(from.isVersions());
       }
       return httpOptions;
    }

--- a/apis/s3/src/main/java/org/jclouds/s3/blobstore/functions/ContainerToBucketListOptions.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/blobstore/functions/ContainerToBucketListOptions.java
@@ -65,7 +65,6 @@ public class ContainerToBucketListOptions implements
       }
       if (from.isVersions()) {
             httpOptions.versions(from.isVersions());
-         System.out.println("PAVAN ContainerToBucketListOptions -> applyupdating the httpOptions versions to:"+httpOptions.getVersions());
       }
       return httpOptions;
    }

--- a/apis/s3/src/main/java/org/jclouds/s3/blobstore/functions/ContainerToBucketListOptions.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/blobstore/functions/ContainerToBucketListOptions.java
@@ -20,10 +20,10 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import javax.inject.Singleton;
 
+import com.google.common.base.Function;
+
 import org.jclouds.blobstore.options.ListContainerOptions;
 import org.jclouds.s3.options.ListBucketOptions;
-
-import com.google.common.base.Function;
 
 @Singleton
 public class ContainerToBucketListOptions implements
@@ -62,6 +62,10 @@ public class ContainerToBucketListOptions implements
       }
       if (from.getMaxResults() != null) {
          httpOptions.maxResults(from.getMaxResults());
+      }
+      if (from.isVersions()) {
+            httpOptions.versions(from.isVersions());
+         System.out.println("PAVAN ContainerToBucketListOptions -> applyupdating the httpOptions versions to:"+httpOptions.getVersions());
       }
       return httpOptions;
    }

--- a/apis/s3/src/main/java/org/jclouds/s3/blobstore/functions/ContainerToBucketListOptions.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/blobstore/functions/ContainerToBucketListOptions.java
@@ -20,10 +20,10 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import javax.inject.Singleton;
 
-import com.google.common.base.Function;
-
 import org.jclouds.blobstore.options.ListContainerOptions;
 import org.jclouds.s3.options.ListBucketOptions;
+
+import com.google.common.base.Function;
 
 @Singleton
 public class ContainerToBucketListOptions implements

--- a/apis/s3/src/main/java/org/jclouds/s3/blobstore/functions/ObjectToBlobMetadata.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/blobstore/functions/ObjectToBlobMetadata.java
@@ -19,14 +19,14 @@ package org.jclouds.s3.blobstore.functions;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import com.google.common.base.Function;
-
 import org.jclouds.blobstore.domain.MutableBlobMetadata;
 import org.jclouds.blobstore.domain.StorageType;
 import org.jclouds.blobstore.domain.internal.MutableBlobMetadataImpl;
 import org.jclouds.domain.Location;
 import org.jclouds.http.HttpUtils;
 import org.jclouds.s3.domain.ObjectMetadata;
+
+import com.google.common.base.Function;
 
 @Singleton
 public class ObjectToBlobMetadata implements Function<ObjectMetadata, MutableBlobMetadata> {

--- a/apis/s3/src/main/java/org/jclouds/s3/blobstore/functions/ObjectToBlobMetadata.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/blobstore/functions/ObjectToBlobMetadata.java
@@ -19,14 +19,14 @@ package org.jclouds.s3.blobstore.functions;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import com.google.common.base.Function;
+
 import org.jclouds.blobstore.domain.MutableBlobMetadata;
 import org.jclouds.blobstore.domain.StorageType;
 import org.jclouds.blobstore.domain.internal.MutableBlobMetadataImpl;
 import org.jclouds.domain.Location;
 import org.jclouds.http.HttpUtils;
 import org.jclouds.s3.domain.ObjectMetadata;
-
-import com.google.common.base.Function;
 
 @Singleton
 public class ObjectToBlobMetadata implements Function<ObjectMetadata, MutableBlobMetadata> {
@@ -52,6 +52,8 @@ public class ObjectToBlobMetadata implements Function<ObjectMetadata, MutableBlo
       to.setType(StorageType.BLOB);
       to.setSize(from.getContentMetadata().getContentLength());
       to.setTier((from.getStorageClass() == null ? ObjectMetadata.StorageClass.STANDARD : from.getStorageClass()).toTier());
+      to.setVersionId(from.getVersionId());
+      to.setIsLatest(from.getIsLatest());
       return to;
    }
 }

--- a/apis/s3/src/main/java/org/jclouds/s3/config/S3HttpApiModule.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/config/S3HttpApiModule.java
@@ -49,6 +49,7 @@ import org.jclouds.s3.blobstore.functions.BucketsToStorageMetadata;
 import org.jclouds.s3.domain.BucketMetadata;
 import org.jclouds.s3.filters.RequestAuthorizeSignature;
 import org.jclouds.s3.filters.RequestAuthorizeSignatureV2;
+import org.jclouds.s3.filters.RequestAuthorizeSignatureV4;
 import org.jclouds.s3.functions.GetRegionForBucket;
 import org.jclouds.s3.handlers.ParseS3ErrorFromXmlContent;
 import org.jclouds.s3.handlers.S3RedirectionRetryHandler;
@@ -184,7 +185,8 @@ public class S3HttpApiModule<S extends S3Client> extends AWSHttpApiModule<S> {
    }
 
    protected void bindRequestSigner() {
-      bind(RequestAuthorizeSignature.class).to(RequestAuthorizeSignatureV2.class).in(Scopes.SINGLETON);
+//      bind(RequestAuthorizeSignature.class).to(RequestAuthorizeSignatureV2.class).in(Scopes.SINGLETON);
+      bind(RequestAuthorizeSignature.class).to(RequestAuthorizeSignatureV4.class).in(Scopes.SINGLETON);
    }
 
    @Provides

--- a/apis/s3/src/main/java/org/jclouds/s3/config/S3HttpApiModule.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/config/S3HttpApiModule.java
@@ -48,7 +48,7 @@ import org.jclouds.s3.S3Client;
 import org.jclouds.s3.blobstore.functions.BucketsToStorageMetadata;
 import org.jclouds.s3.domain.BucketMetadata;
 import org.jclouds.s3.filters.RequestAuthorizeSignature;
-import org.jclouds.s3.filters.RequestAuthorizeSignatureV4;
+import org.jclouds.s3.filters.RequestAuthorizeSignatureV2;
 import org.jclouds.s3.functions.GetRegionForBucket;
 import org.jclouds.s3.handlers.ParseS3ErrorFromXmlContent;
 import org.jclouds.s3.handlers.S3RedirectionRetryHandler;
@@ -184,7 +184,7 @@ public class S3HttpApiModule<S extends S3Client> extends AWSHttpApiModule<S> {
    }
 
    protected void bindRequestSigner() {
-      bind(RequestAuthorizeSignature.class).to(RequestAuthorizeSignatureV4.class).in(Scopes.SINGLETON);
+      bind(RequestAuthorizeSignature.class).to(RequestAuthorizeSignatureV2.class).in(Scopes.SINGLETON);
    }
 
    @Provides

--- a/apis/s3/src/main/java/org/jclouds/s3/config/S3HttpApiModule.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/config/S3HttpApiModule.java
@@ -184,7 +184,6 @@ public class S3HttpApiModule<S extends S3Client> extends AWSHttpApiModule<S> {
    }
 
    protected void bindRequestSigner() {
-//      bind(RequestAuthorizeSignature.class).to(RequestAuthorizeSignatureV2.class).in(Scopes.SINGLETON);
       bind(RequestAuthorizeSignature.class).to(RequestAuthorizeSignatureV4.class).in(Scopes.SINGLETON);
    }
 

--- a/apis/s3/src/main/java/org/jclouds/s3/config/S3HttpApiModule.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/config/S3HttpApiModule.java
@@ -48,7 +48,6 @@ import org.jclouds.s3.S3Client;
 import org.jclouds.s3.blobstore.functions.BucketsToStorageMetadata;
 import org.jclouds.s3.domain.BucketMetadata;
 import org.jclouds.s3.filters.RequestAuthorizeSignature;
-import org.jclouds.s3.filters.RequestAuthorizeSignatureV2;
 import org.jclouds.s3.filters.RequestAuthorizeSignatureV4;
 import org.jclouds.s3.functions.GetRegionForBucket;
 import org.jclouds.s3.handlers.ParseS3ErrorFromXmlContent;

--- a/apis/s3/src/main/java/org/jclouds/s3/domain/ListVersionsResponse.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/domain/ListVersionsResponse.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.s3.domain;
+
+import java.util.Set;
+
+/**
+ * A container that provides namespace, access control and aggregation of {@link S3Object}s
+ * <p/>
+ * <p/>
+ * Every object stored in Amazon S3 is contained in a bucket. Buckets partition the namespace of
+ * objects stored in Amazon S3 at the top level. Within a bucket, you can use any names for your
+ * objects, but bucket names must be unique across all of Amazon S3.
+ * <p/>
+ * Buckets are similar to Internet domain names. Just as Amazon is the only owner of the domain name
+ * Amazon.com, only one person or organization can own a bucket within Amazon S3. Once you create a
+ * uniquely named bucket in Amazon S3, you can organize and name the objects within the bucket in
+ * any way you like and the bucket will remain yours for as long as you like and as long as you have
+ * the Amazon S3 identity.
+ * <p/>
+ * The similarities between buckets and domain names is not a coincidence there is a direct mapping
+ * between Amazon S3 buckets and subdomains of s3.amazonaws.com. Objects stored in Amazon S3 are
+ * addressable using the REST API under the domain bucketname.s3.amazonaws.com. For example, if the
+ * object homepage.html?is stored in the Amazon S3 bucket mybucket its address would be
+ * http://mybucket.s3.amazonaws.com/homepage.html?
+ */
+public interface ListVersionsResponse extends Set<ObjectMetadata> {
+
+   /**
+    * Limits the response to keys which begin with the indicated prefix. You can use prefixes to
+    * separate a bucket into different sets of keys in a way similar to how a file system uses
+    * folders.
+    */
+   String getPrefix();
+
+   /**
+    * Indicates where in the bucket to begin listing. The list will only include keys that occur
+    * lexicographically after marker. This is convenient for pagination: To get the next page of
+    * results use the last key of the current page as the marker.
+    */
+   String getNextMarker();
+
+   String getMarker();
+
+   /**
+    * The maximum number of keys you'd like to see in the response body. The server might return
+    * fewer than this many keys, but will not return more.
+    */
+   int getMaxKeys();
+
+   /**
+    * There are more then maxKeys available
+    */
+   boolean isTruncated();
+
+   /**
+    * Causes keys that contain the same string between the prefix and the first occurrence of the
+    * delimiter to be rolled up into a single result element in the CommonPrefixes collection. These
+    * rolled-up keys are not returned elsewhere in the response.
+    * 
+    */
+   String getDelimiter();
+
+   /**
+    * Example:
+    * <p/>
+    * if the following keys are in the bucket
+    * <p/>
+    * a/1/a<br/>
+    * a/1/b<br/>
+    * a/2/a<br/>
+    * a/2/b<br/>
+    * <p/>
+    * and prefix is set to <code>a/</code> and delimiter is set to <code>/</code> then
+    * commonprefixes would return 1,2
+    * 
+    * @see org.jclouds.s3.options.ListBucketOptions#getPrefix()
+    */
+   Set<String> getCommonPrefixes();
+
+   String getNextVersionIdMarker();
+   String getVersionIdMarker();
+
+   /**
+    * name of the Bucket
+    */
+   String getName();
+
+}

--- a/apis/s3/src/main/java/org/jclouds/s3/domain/MutableObjectMetadata.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/domain/MutableObjectMetadata.java
@@ -20,11 +20,10 @@ import java.net.URI;
 import java.util.Date;
 import java.util.Map;
 
-import org.jclouds.io.MutableContentMetadata;
-import org.jclouds.s3.domain.ObjectMetadata.StorageClass;
-import org.jclouds.s3.domain.internal.MutableObjectMetadataImpl;
-
 import com.google.inject.ImplementedBy;
+
+import org.jclouds.io.MutableContentMetadata;
+import org.jclouds.s3.domain.internal.MutableObjectMetadataImpl;
 
 /**
  * /** Amazon S3 is designed to store objects. Objects are stored in {@link ListBucketResponse buckets}
@@ -74,6 +73,10 @@ public interface MutableObjectMetadata extends ObjectMetadata {
    void setLastModified(Date lastModified);
 
    void setETag(String eTag);
+
+   void setVersionId(String versionId);
+
+   void setIsLatest(String isLatest);
 
    void setUserMetadata(Map<String, String> userMetadata);
 

--- a/apis/s3/src/main/java/org/jclouds/s3/domain/MutableObjectMetadata.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/domain/MutableObjectMetadata.java
@@ -20,10 +20,11 @@ import java.net.URI;
 import java.util.Date;
 import java.util.Map;
 
-import com.google.inject.ImplementedBy;
-
 import org.jclouds.io.MutableContentMetadata;
+import org.jclouds.s3.domain.ObjectMetadata.StorageClass;
 import org.jclouds.s3.domain.internal.MutableObjectMetadataImpl;
+
+import com.google.inject.ImplementedBy;
 
 /**
  * /** Amazon S3 is designed to store objects. Objects are stored in {@link ListBucketResponse buckets}

--- a/apis/s3/src/main/java/org/jclouds/s3/domain/ObjectMetadata.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/domain/ObjectMetadata.java
@@ -27,7 +27,7 @@ import org.jclouds.io.ContentMetadata;
 
 /**
  * Amazon S3 is designed to store objects. Objects are stored in {@link S3BucketListing buckets}
- * and consist of a {@link org.jclouds.s3.domain.S3Object#getData() value}, a
+ * and consist of a {@link S3Object#getData() value}, a
  * {@link S3Object#getKey key}, {@link ObjectMetadata#getUserMetadata() metadata}, and an access
  * control policy.
  */
@@ -100,6 +100,10 @@ public interface ObjectMetadata extends Comparable<ObjectMetadata> {
    Date getLastModified();
 
    String getETag();
+
+   String getVersionId();
+
+   String getIsLatest();
 
    Map<String, String> getUserMetadata();
 

--- a/apis/s3/src/main/java/org/jclouds/s3/domain/ObjectMetadata.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/domain/ObjectMetadata.java
@@ -27,7 +27,7 @@ import org.jclouds.io.ContentMetadata;
 
 /**
  * Amazon S3 is designed to store objects. Objects are stored in {@link S3BucketListing buckets}
- * and consist of a {@link S3Object#getData() value}, a
+ * and consist of a {@link org.jclouds.s3.domain.S3Object#getData() value}, a
  * {@link S3Object#getKey key}, {@link ObjectMetadata#getUserMetadata() metadata}, and an access
  * control policy.
  */

--- a/apis/s3/src/main/java/org/jclouds/s3/domain/ObjectMetadataBuilder.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/domain/ObjectMetadataBuilder.java
@@ -20,12 +20,12 @@ import java.net.URI;
 import java.util.Date;
 import java.util.Map;
 
-import com.google.common.collect.ImmutableMap;
-
 import org.jclouds.io.ContentMetadataBuilder;
 import org.jclouds.io.payloads.BaseMutableContentMetadata;
 import org.jclouds.s3.domain.ObjectMetadata.StorageClass;
 import org.jclouds.s3.domain.internal.MutableObjectMetadataImpl;
+
+import com.google.common.collect.ImmutableMap;
 
 /**
  * Allows you to create {@link ObjectMetadata} objects.

--- a/apis/s3/src/main/java/org/jclouds/s3/domain/ObjectMetadataBuilder.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/domain/ObjectMetadataBuilder.java
@@ -20,12 +20,12 @@ import java.net.URI;
 import java.util.Date;
 import java.util.Map;
 
+import com.google.common.collect.ImmutableMap;
+
 import org.jclouds.io.ContentMetadataBuilder;
 import org.jclouds.io.payloads.BaseMutableContentMetadata;
 import org.jclouds.s3.domain.ObjectMetadata.StorageClass;
 import org.jclouds.s3.domain.internal.MutableObjectMetadataImpl;
-
-import com.google.common.collect.ImmutableMap;
 
 /**
  * Allows you to create {@link ObjectMetadata} objects.
@@ -44,6 +44,8 @@ public class ObjectMetadataBuilder {
    private StorageClass storageClass = StorageClass.STANDARD;
    private Date lastModified;
    private String eTag;
+   private String versionId;
+   private String isLatest;
    private CanonicalUser owner;
    private Map<String, String> userMetadata = ImmutableMap.of();
 
@@ -64,6 +66,16 @@ public class ObjectMetadataBuilder {
 
    public ObjectMetadataBuilder eTag(String eTag) {
       this.eTag = eTag;
+      return this;
+   }
+
+   public ObjectMetadataBuilder versionId(String versionId) {
+      this.versionId = versionId;
+      return this;
+   }
+
+   public ObjectMetadataBuilder isLatest(String isLatest) {
+      this.isLatest = isLatest;
       return this;
    }
 
@@ -133,6 +145,8 @@ public class ObjectMetadataBuilder {
       toReturn.setBucket(bucket);
       toReturn.setUri(uri);
       toReturn.setETag(eTag);
+      toReturn.setVersionId(versionId);
+      toReturn.setIsLatest(isLatest);
       toReturn.setOwner(owner);
       toReturn.setStorageClass(storageClass);
       toReturn.setUserMetadata(userMetadata);

--- a/apis/s3/src/main/java/org/jclouds/s3/domain/internal/BucketListObjectMetadata.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/domain/internal/BucketListObjectMetadata.java
@@ -22,12 +22,12 @@ import java.net.URI;
 import java.util.Date;
 import java.util.Map;
 
-import com.google.common.collect.ImmutableMap;
-
 import org.jclouds.io.ContentMetadata;
 import org.jclouds.io.payloads.BaseImmutableContentMetadata;
 import org.jclouds.s3.domain.CanonicalUser;
 import org.jclouds.s3.domain.ObjectMetadata;
+
+import com.google.common.collect.ImmutableMap;
 
 /**
  * Returns the metadata parsable from a bucket listing
@@ -46,7 +46,7 @@ public class BucketListObjectMetadata implements ObjectMetadata {
    private final ContentMetadata contentMetadata;
 
    public BucketListObjectMetadata(String key, String bucket, URI uri, Date lastModified, String eTag, byte[] md5,
-                                   long contentLength, CanonicalUser owner, StorageClass storageClass) {
+            long contentLength, CanonicalUser owner, StorageClass storageClass) {
       this.key = checkNotNull(key, "key");
       this.bucket = checkNotNull(bucket, "bucket");
       this.uri = checkNotNull(uri, "uri");

--- a/apis/s3/src/main/java/org/jclouds/s3/domain/internal/BucketListObjectMetadata.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/domain/internal/BucketListObjectMetadata.java
@@ -52,7 +52,7 @@ public class BucketListObjectMetadata implements ObjectMetadata {
       this.uri = checkNotNull(uri, "uri");
       this.lastModified = lastModified;
       this.eTag = eTag;
-      this.versionId=null;
+      this.versionId = null;
       this.isLatest = null;
       this.owner = owner;
       this.contentMetadata = new BaseImmutableContentMetadata(null, contentLength, md5, null, null, null, null);

--- a/apis/s3/src/main/java/org/jclouds/s3/domain/internal/BucketListObjectMetadata.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/domain/internal/BucketListObjectMetadata.java
@@ -22,12 +22,12 @@ import java.net.URI;
 import java.util.Date;
 import java.util.Map;
 
+import com.google.common.collect.ImmutableMap;
+
 import org.jclouds.io.ContentMetadata;
 import org.jclouds.io.payloads.BaseImmutableContentMetadata;
 import org.jclouds.s3.domain.CanonicalUser;
 import org.jclouds.s3.domain.ObjectMetadata;
-
-import com.google.common.collect.ImmutableMap;
 
 /**
  * Returns the metadata parsable from a bucket listing
@@ -39,17 +39,21 @@ public class BucketListObjectMetadata implements ObjectMetadata {
    private final URI uri;
    private final Date lastModified;
    private final String eTag;
+   private final String versionId;
+   private final String isLatest;
    private final CanonicalUser owner;
    private final StorageClass storageClass;
    private final ContentMetadata contentMetadata;
 
    public BucketListObjectMetadata(String key, String bucket, URI uri, Date lastModified, String eTag, byte[] md5,
-            long contentLength, CanonicalUser owner, StorageClass storageClass) {
+                                   long contentLength, CanonicalUser owner, StorageClass storageClass) {
       this.key = checkNotNull(key, "key");
       this.bucket = checkNotNull(bucket, "bucket");
       this.uri = checkNotNull(uri, "uri");
       this.lastModified = lastModified;
       this.eTag = eTag;
+      this.versionId=null;
+      this.isLatest = null;
       this.owner = owner;
       this.contentMetadata = new BaseImmutableContentMetadata(null, contentLength, md5, null, null, null, null);
       this.storageClass = storageClass;
@@ -117,6 +121,16 @@ public class BucketListObjectMetadata implements ObjectMetadata {
    @Override
    public String getETag() {
       return eTag;
+   }
+
+   @Override
+   public String getVersionId() {
+      return versionId;
+   }
+
+   @Override
+   public String getIsLatest() {
+      return null;
    }
 
    /**

--- a/apis/s3/src/main/java/org/jclouds/s3/domain/internal/CopyObjectResult.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/domain/internal/CopyObjectResult.java
@@ -20,12 +20,12 @@ import java.net.URI;
 import java.util.Date;
 import java.util.Map;
 
+import com.google.common.collect.ImmutableMap;
+
 import org.jclouds.io.ContentMetadata;
 import org.jclouds.io.payloads.BaseImmutableContentMetadata;
 import org.jclouds.s3.domain.CanonicalUser;
 import org.jclouds.s3.domain.ObjectMetadata;
-
-import com.google.common.collect.ImmutableMap;
 
 /**
  * Returns the metadata parsable from a bucket listing
@@ -35,10 +35,22 @@ public class CopyObjectResult implements ObjectMetadata {
    private final Date lastModified;
    private final String eTag;
    private final BaseImmutableContentMetadata contentMetadata;
+   private final String versionId;
+   private final String isLatest;
 
    public CopyObjectResult(Date lastModified, String eTag) {
       this.lastModified = lastModified;
       this.eTag = eTag;
+      this.versionId=null;
+      this.isLatest=null;
+      this.contentMetadata = new BaseImmutableContentMetadata(null, null, null, null, null, null, null);
+   }
+
+   public CopyObjectResult(Date lastModified, String eTag, String version) {
+      this.lastModified = lastModified;
+      this.eTag = eTag;
+      this.versionId = version;
+      this.isLatest = null;
       this.contentMetadata = new BaseImmutableContentMetadata(null, null, null, null, null, null, null);
    }
 
@@ -104,6 +116,16 @@ public class CopyObjectResult implements ObjectMetadata {
    @Override
    public String getETag() {
       return eTag;
+   }
+
+   @Override
+   public String getVersionId() {
+      return versionId;
+   }
+
+   @Override
+   public String getIsLatest() {
+      return isLatest;
    }
 
    /**

--- a/apis/s3/src/main/java/org/jclouds/s3/domain/internal/CopyObjectResult.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/domain/internal/CopyObjectResult.java
@@ -20,12 +20,12 @@ import java.net.URI;
 import java.util.Date;
 import java.util.Map;
 
-import com.google.common.collect.ImmutableMap;
-
 import org.jclouds.io.ContentMetadata;
 import org.jclouds.io.payloads.BaseImmutableContentMetadata;
 import org.jclouds.s3.domain.CanonicalUser;
 import org.jclouds.s3.domain.ObjectMetadata;
+
+import com.google.common.collect.ImmutableMap;
 
 /**
  * Returns the metadata parsable from a bucket listing

--- a/apis/s3/src/main/java/org/jclouds/s3/domain/internal/CopyObjectResult.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/domain/internal/CopyObjectResult.java
@@ -41,8 +41,8 @@ public class CopyObjectResult implements ObjectMetadata {
    public CopyObjectResult(Date lastModified, String eTag) {
       this.lastModified = lastModified;
       this.eTag = eTag;
-      this.versionId=null;
-      this.isLatest=null;
+      this.versionId = null;
+      this.isLatest = null;
       this.contentMetadata = new BaseImmutableContentMetadata(null, null, null, null, null, null, null);
    }
 

--- a/apis/s3/src/main/java/org/jclouds/s3/domain/internal/ListVersionsResponseImpl.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/domain/internal/ListVersionsResponseImpl.java
@@ -19,13 +19,14 @@ package org.jclouds.s3.domain.internal;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 
 import org.jclouds.s3.domain.ListVersionsResponse;
 import org.jclouds.s3.domain.ObjectMetadata;
 
 public class ListVersionsResponseImpl extends LinkedHashSet<ObjectMetadata>
-    implements ListVersionsResponse {
+        implements ListVersionsResponse {
 
     protected final String name;
     protected final String prefix;
@@ -44,7 +45,7 @@ public class ListVersionsResponseImpl extends LinkedHashSet<ObjectMetadata>
                                     String nextMarker, int maxKeys,
                                     String delimiter, boolean truncated,
                                     Set<String> commonPrefixes
-                                    ) {
+    ) {
         Iterables.addAll(this, version);
         this.name = name;
         this.prefix = prefix;
@@ -135,74 +136,25 @@ public class ListVersionsResponseImpl extends LinkedHashSet<ObjectMetadata>
 
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result +
-            ((commonPrefixes == null) ? 0 : commonPrefixes.hashCode());
-        result =
-            prime * result + ((delimiter == null) ? 0 : delimiter.hashCode());
-        result = prime * result + ((marker == null) ? 0 : marker.hashCode());
-        result = prime * result + maxKeys;
-        result = prime * result + ((name == null) ? 0 : name.hashCode());
-        result = prime * result + ((prefix == null) ? 0 : prefix.hashCode());
-        result = prime * result + (truncated ? 1231 : 1237);
-        return result;
+        return Objects.hashCode(commonPrefixes, delimiter, marker, maxKeys, name, prefix, truncated);
     }
 
     @Override
     public boolean equals(Object obj) {
-       if (this == obj) {
-          return true;
-       }
-       if (!super.equals(obj)) {
-          return false;
-       }
-       if (getClass() != obj.getClass()) {
-          return false;
-       }
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
         ListVersionsResponseImpl other = (ListVersionsResponseImpl) obj;
-        if (commonPrefixes == null) {
-           if (other.commonPrefixes != null) {
-              return false;
-           }
-        } else if (!commonPrefixes.equals(other.commonPrefixes)) {
-           return false;
-        }
-        if (delimiter == null) {
-           if (other.delimiter != null) {
-              return false;
-           }
-        } else if (!delimiter.equals(other.delimiter)) {
-           return false;
-        }
-        if (marker == null) {
-           if (other.marker != null) {
-              return false;
-           }
-        } else if (!marker.equals(other.marker)) {
-           return false;
-        }
-       if (maxKeys != other.maxKeys) {
-          return false;
-       }
-        if (name == null) {
-           if (other.name != null) {
-              return false;
-           }
-        } else if (!name.equals(other.name)) {
-           return false;
-        }
-        if (prefix == null) {
-           if (other.prefix != null) {
-              return false;
-           }
-        } else if (!prefix.equals(other.prefix)) {
-           return false;
-        }
-       if (truncated != other.truncated) {
-          return false;
-       }
-        return true;
-    }
+        return (truncated == other.truncated) &&
+                maxKeys == other.maxKeys &&
+                Objects.equal(name, other.name) &&
+                Objects.equal(prefix, other.prefix) &&
+                Objects.equal(marker, other.marker) &&
+                Objects.equal(delimiter, other.delimiter) &&
+                Objects.equal(commonPrefixes, other.commonPrefixes);
 
+    }
 }

--- a/apis/s3/src/main/java/org/jclouds/s3/domain/internal/ListVersionsResponseImpl.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/domain/internal/ListVersionsResponseImpl.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.s3.domain.internal;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import com.google.common.collect.Iterables;
+
+import org.jclouds.s3.domain.ListVersionsResponse;
+import org.jclouds.s3.domain.ObjectMetadata;
+
+public class ListVersionsResponseImpl extends LinkedHashSet<ObjectMetadata>
+    implements ListVersionsResponse {
+
+    protected final String name;
+    protected final String prefix;
+    protected final int maxKeys;
+    protected final String delimiter;
+    protected final String marker;
+    protected final String nextMarker;
+    protected final Set<String> commonPrefixes;
+    protected final boolean truncated;
+    protected final String nextVersionIdMarker;
+    protected final String versionIdMarker;
+
+    public ListVersionsResponseImpl(String name,
+                                    Iterable<ObjectMetadata> version,
+                                    String prefix, String marker,
+                                    String nextMarker, int maxKeys,
+                                    String delimiter, boolean truncated,
+                                    Set<String> commonPrefixes
+                                    ) {
+        Iterables.addAll(this, version);
+        this.name = name;
+        this.prefix = prefix;
+        this.maxKeys = maxKeys;
+        this.delimiter = delimiter;
+        this.marker = marker;
+        this.nextMarker = nextMarker;
+        this.commonPrefixes = commonPrefixes;
+        this.truncated = truncated;
+        this.nextVersionIdMarker = null;
+        this.versionIdMarker = null;
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Set<String> getCommonPrefixes() {
+        return commonPrefixes;
+    }
+
+    @Override
+    public String getNextVersionIdMarker() {
+        return null;
+    }
+
+    @Override
+    public String getVersionIdMarker() {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getDelimiter() {
+        return delimiter;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getMarker() {
+        return marker;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getNextMarker() {
+        return nextMarker;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getMaxKeys() {
+        return maxKeys;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getPrefix() {
+        return prefix;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isTruncated() {
+        return truncated;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result +
+            ((commonPrefixes == null) ? 0 : commonPrefixes.hashCode());
+        result =
+            prime * result + ((delimiter == null) ? 0 : delimiter.hashCode());
+        result = prime * result + ((marker == null) ? 0 : marker.hashCode());
+        result = prime * result + maxKeys;
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        result = prime * result + ((prefix == null) ? 0 : prefix.hashCode());
+        result = prime * result + (truncated ? 1231 : 1237);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+       if (this == obj) {
+          return true;
+       }
+       if (!super.equals(obj)) {
+          return false;
+       }
+       if (getClass() != obj.getClass()) {
+          return false;
+       }
+        ListVersionsResponseImpl other = (ListVersionsResponseImpl) obj;
+        if (commonPrefixes == null) {
+           if (other.commonPrefixes != null) {
+              return false;
+           }
+        } else if (!commonPrefixes.equals(other.commonPrefixes)) {
+           return false;
+        }
+        if (delimiter == null) {
+           if (other.delimiter != null) {
+              return false;
+           }
+        } else if (!delimiter.equals(other.delimiter)) {
+           return false;
+        }
+        if (marker == null) {
+           if (other.marker != null) {
+              return false;
+           }
+        } else if (!marker.equals(other.marker)) {
+           return false;
+        }
+       if (maxKeys != other.maxKeys) {
+          return false;
+       }
+        if (name == null) {
+           if (other.name != null) {
+              return false;
+           }
+        } else if (!name.equals(other.name)) {
+           return false;
+        }
+        if (prefix == null) {
+           if (other.prefix != null) {
+              return false;
+           }
+        } else if (!prefix.equals(other.prefix)) {
+           return false;
+        }
+       if (truncated != other.truncated) {
+          return false;
+       }
+        return true;
+    }
+
+}

--- a/apis/s3/src/main/java/org/jclouds/s3/domain/internal/MutableObjectMetadataImpl.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/domain/internal/MutableObjectMetadataImpl.java
@@ -19,9 +19,6 @@ package org.jclouds.s3.domain.internal;
 import java.net.URI;
 import java.util.Date;
 import java.util.Map;
-import java.util.Objects;
-
-import com.google.common.collect.Maps;
 
 import org.jclouds.http.HttpUtils;
 import org.jclouds.io.MutableContentMetadata;
@@ -29,6 +26,8 @@ import org.jclouds.io.payloads.BaseMutableContentMetadata;
 import org.jclouds.s3.domain.CanonicalUser;
 import org.jclouds.s3.domain.MutableObjectMetadata;
 import org.jclouds.s3.domain.ObjectMetadata;
+
+import com.google.common.collect.Maps;
 
 /**
  * Allows you to manipulate metadata.
@@ -188,7 +187,6 @@ public class MutableObjectMetadataImpl implements MutableObjectMetadata {
       this.isLatest = isLatest;
    }
 
-
    /**
     *{@inheritDoc}
     */
@@ -255,32 +253,27 @@ public class MutableObjectMetadataImpl implements MutableObjectMetadata {
 
    @Override
    public int hashCode() {
-      return Objects.hash(key, bucket, uri, lastModified, eTag, versionId,
-          isLatest, owner, storageClass, cacheControl, userMetadata,
-          contentMetadata);
+      final int prime = 31;
+      int result = 1;
+      result = prime * result + ((uri == null) ? 0 : uri.hashCode());
+      return result;
    }
 
    @Override
-   public boolean equals(Object o) {
-      if (this == o) {
+   public boolean equals(Object obj) {
+      if (this == obj)
          return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
+      if (obj == null)
          return false;
-      }
-      MutableObjectMetadataImpl that = (MutableObjectMetadataImpl) o;
-      return Objects.equals(key, that.key) &&
-          Objects.equals(bucket, that.bucket) &&
-          Objects.equals(uri, that.uri) &&
-          Objects.equals(lastModified, that.lastModified) &&
-          Objects.equals(eTag, that.eTag) &&
-          Objects.equals(versionId, that.versionId) &&
-          Objects.equals(isLatest, that.isLatest) &&
-          Objects.equals(owner, that.owner) &&
-          storageClass == that.storageClass &&
-          Objects.equals(cacheControl, that.cacheControl) &&
-          Objects.equals(userMetadata, that.userMetadata) &&
-          Objects.equals(contentMetadata, that.contentMetadata);
+      if (getClass() != obj.getClass())
+         return false;
+      MutableObjectMetadataImpl other = (MutableObjectMetadataImpl) obj;
+      if (uri == null) {
+         if (other.uri != null)
+            return false;
+      } else if (!uri.equals(other.uri))
+         return false;
+      return true;
    }
 
    @Override

--- a/apis/s3/src/main/java/org/jclouds/s3/domain/internal/MutableObjectMetadataImpl.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/domain/internal/MutableObjectMetadataImpl.java
@@ -19,6 +19,9 @@ package org.jclouds.s3.domain.internal;
 import java.net.URI;
 import java.util.Date;
 import java.util.Map;
+import java.util.Objects;
+
+import com.google.common.collect.Maps;
 
 import org.jclouds.http.HttpUtils;
 import org.jclouds.io.MutableContentMetadata;
@@ -26,8 +29,6 @@ import org.jclouds.io.payloads.BaseMutableContentMetadata;
 import org.jclouds.s3.domain.CanonicalUser;
 import org.jclouds.s3.domain.MutableObjectMetadata;
 import org.jclouds.s3.domain.ObjectMetadata;
-
-import com.google.common.collect.Maps;
 
 /**
  * Allows you to manipulate metadata.
@@ -39,6 +40,8 @@ public class MutableObjectMetadataImpl implements MutableObjectMetadata {
    private URI uri;
    private Date lastModified;
    private String eTag;
+   private String versionId;
+   private String isLatest;
    private CanonicalUser owner;
    private StorageClass storageClass;
    private String cacheControl;
@@ -132,6 +135,16 @@ public class MutableObjectMetadataImpl implements MutableObjectMetadata {
       return eTag;
    }
 
+   @Override
+   public String getVersionId() {
+      return versionId;
+   }
+
+   @Override
+   public String getIsLatest() {
+      return isLatest;
+   }
+
    /**
     *{@inheritDoc}
     */
@@ -164,6 +177,17 @@ public class MutableObjectMetadataImpl implements MutableObjectMetadata {
    public void setETag(String eTag) {
       this.eTag = eTag;
    }
+
+   @Override
+   public void setVersionId(String versionId) {
+      this.versionId = versionId;
+   }
+
+   @Override
+   public void setIsLatest(String isLatest) {
+      this.isLatest = isLatest;
+   }
+
 
    /**
     *{@inheritDoc}
@@ -231,28 +255,58 @@ public class MutableObjectMetadataImpl implements MutableObjectMetadata {
 
    @Override
    public int hashCode() {
-      final int prime = 31;
-      int result = 1;
-      result = prime * result + ((uri == null) ? 0 : uri.hashCode());
-      return result;
+      return Objects.hash(key, bucket, uri, lastModified, eTag, versionId,
+          isLatest, owner, storageClass, cacheControl, userMetadata,
+          contentMetadata);
    }
 
    @Override
-   public boolean equals(Object obj) {
-      if (this == obj)
+   public boolean equals(Object o) {
+      if (this == o) {
          return true;
-      if (obj == null)
+      }
+      if (o == null || getClass() != o.getClass()) {
          return false;
-      if (getClass() != obj.getClass())
-         return false;
-      MutableObjectMetadataImpl other = (MutableObjectMetadataImpl) obj;
-      if (uri == null) {
-         if (other.uri != null)
-            return false;
-      } else if (!uri.equals(other.uri))
-         return false;
-      return true;
+      }
+      MutableObjectMetadataImpl that = (MutableObjectMetadataImpl) o;
+      return Objects.equals(key, that.key) &&
+          Objects.equals(bucket, that.bucket) &&
+          Objects.equals(uri, that.uri) &&
+          Objects.equals(lastModified, that.lastModified) &&
+          Objects.equals(eTag, that.eTag) &&
+          Objects.equals(versionId, that.versionId) &&
+          Objects.equals(isLatest, that.isLatest) &&
+          Objects.equals(owner, that.owner) &&
+          storageClass == that.storageClass &&
+          Objects.equals(cacheControl, that.cacheControl) &&
+          Objects.equals(userMetadata, that.userMetadata) &&
+          Objects.equals(contentMetadata, that.contentMetadata);
    }
+
+//   @Override
+//   public int hashCode() {
+//      final int prime = 31;
+//      int result = 1;
+//      result = prime * result + ((uri == null) ? 0 : uri.hashCode());
+//      return result;
+//   }
+
+//   @Override
+//   public boolean equals(Object obj) {
+//      if (this == obj)
+//         return true;
+//      if (obj == null)
+//         return false;
+//      if (getClass() != obj.getClass())
+//         return false;
+//      MutableObjectMetadataImpl other = (MutableObjectMetadataImpl) obj;
+//      if (uri == null) {
+//         if (other.uri != null)
+//            return false;
+//      } else if (!uri.equals(other.uri))
+//         return false;
+//      return true;
+//   }
 
    @Override
    public String toString() {

--- a/apis/s3/src/main/java/org/jclouds/s3/domain/internal/MutableObjectMetadataImpl.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/domain/internal/MutableObjectMetadataImpl.java
@@ -283,31 +283,6 @@ public class MutableObjectMetadataImpl implements MutableObjectMetadata {
           Objects.equals(contentMetadata, that.contentMetadata);
    }
 
-//   @Override
-//   public int hashCode() {
-//      final int prime = 31;
-//      int result = 1;
-//      result = prime * result + ((uri == null) ? 0 : uri.hashCode());
-//      return result;
-//   }
-
-//   @Override
-//   public boolean equals(Object obj) {
-//      if (this == obj)
-//         return true;
-//      if (obj == null)
-//         return false;
-//      if (getClass() != obj.getClass())
-//         return false;
-//      MutableObjectMetadataImpl other = (MutableObjectMetadataImpl) obj;
-//      if (uri == null) {
-//         if (other.uri != null)
-//            return false;
-//      } else if (!uri.equals(other.uri))
-//         return false;
-//      return true;
-//   }
-
    @Override
    public String toString() {
       return String

--- a/apis/s3/src/main/java/org/jclouds/s3/options/BucketConfigOptions.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/options/BucketConfigOptions.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.s3.options;
+
+import org.jclouds.http.options.BaseHttpRequestOptions;
+
+public class BucketConfigOptions extends BaseHttpRequestOptions {
+    public BucketConfigOptions versioning() {
+        this.queryParameters.put("versioning", "true");
+        return this;
+    }
+    public BucketConfigOptions encryption() {
+        this.queryParameters.put("encryption", "");
+        return this;
+    }
+    public BucketConfigOptions lifecycle() {
+        this.queryParameters.put("lifecycle", "");
+        return this;
+    }
+
+
+    public static class Builder {
+        public BucketConfigOptions versioning() {
+            return new BucketConfigOptions().versioning();
+        }
+        public BucketConfigOptions encryption() {
+            return new BucketConfigOptions().encryption();
+        }
+        public BucketConfigOptions lifecycle() {
+            return new BucketConfigOptions().lifecycle();
+        }
+    }
+}

--- a/apis/s3/src/main/java/org/jclouds/s3/options/BucketConfigOptions.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/options/BucketConfigOptions.java
@@ -24,11 +24,11 @@ public class BucketConfigOptions extends BaseHttpRequestOptions {
         return this;
     }
     public BucketConfigOptions encryption() {
-        this.queryParameters.put("encryption", "");
+        this.queryParameters.put("encryption", "true");
         return this;
     }
     public BucketConfigOptions lifecycle() {
-        this.queryParameters.put("lifecycle", "");
+        this.queryParameters.put("lifecycle", "true");
         return this;
     }
 

--- a/apis/s3/src/main/java/org/jclouds/s3/options/ListBucketOptions.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/options/ListBucketOptions.java
@@ -96,6 +96,13 @@ public class ListBucketOptions extends BaseHttpRequestOptions implements Cloneab
       return getFirstQueryOrNull("delimiter");
    }
 
+   public ListBucketOptions versions(Boolean versions) {
+      this.queryParameters.put("versions", checkNotNull(versions, "versions") + "");
+      return this;
+   }
+
+   public Boolean getVersions() { return Boolean.valueOf(getFirstQueryOrNull("versions"));  }
+
    public static class Builder {
 
       /**
@@ -128,6 +135,10 @@ public class ListBucketOptions extends BaseHttpRequestOptions implements Cloneab
       public static ListBucketOptions delimiter(String delimiter) {
          ListBucketOptions options = new ListBucketOptions();
          return options.delimiter(delimiter);
+      }
+
+      public ListBucketOptions versions(Boolean versions) {
+         return new ListBucketOptions().versions(versions);
       }
 
    }

--- a/apis/s3/src/main/java/org/jclouds/s3/options/ListBucketOptions.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/options/ListBucketOptions.java
@@ -101,7 +101,10 @@ public class ListBucketOptions extends BaseHttpRequestOptions implements Cloneab
       return this;
    }
 
-   public Boolean getVersions() { return Boolean.valueOf(getFirstQueryOrNull("versions"));  }
+   public Boolean getVersions() {
+      String versions = getFirstQueryOrNull("versions");
+      return Boolean.valueOf(versions);
+   }
 
    public static class Builder {
 

--- a/apis/s3/src/main/java/org/jclouds/s3/xml/BucketConfigurationHandler.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/xml/BucketConfigurationHandler.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.s3.xml;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import com.google.common.base.Function;
+
+import org.jclouds.http.HttpResponse;
+import org.jclouds.http.functions.ReturnStringIf2xx;
+
+/**
+ * Parses the following XML document:
+ * <p/>
+ * ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01"
+ */
+@Singleton
+public class BucketConfigurationHandler implements Function<HttpResponse, String> {
+   private final ReturnStringIf2xx returnStringIf200;
+
+   @Inject
+   public BucketConfigurationHandler(ReturnStringIf2xx returnStringIf200) {
+      this.returnStringIf200 = returnStringIf200;
+   }
+
+   @Override
+   public String apply(HttpResponse response) {
+      String content = returnStringIf200.apply(response);
+      return content;
+   }
+}

--- a/apis/s3/src/main/java/org/jclouds/s3/xml/ListVersionHandler.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/xml/ListVersionHandler.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.s3.xml;
+
+import static com.google.common.io.BaseEncoding.base16;
+import static org.jclouds.http.Uris.uriBuilder;
+import static org.jclouds.util.SaxUtils.currentOrNull;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.inject.Inject;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSet.Builder;
+
+import org.jclouds.date.DateService;
+import org.jclouds.http.functions.ParseSax;
+import org.jclouds.s3.domain.CanonicalUser;
+import org.jclouds.s3.domain.ListVersionsResponse;
+import org.jclouds.s3.domain.ObjectMetadata;
+import org.jclouds.s3.domain.ObjectMetadataBuilder;
+import org.jclouds.s3.domain.internal.ListVersionsResponseImpl;
+import org.jclouds.util.Strings2;
+import org.xml.sax.Attributes;
+
+/**
+ * Parses the following XML document:
+ * <p/>
+ * ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01"
+ */
+public class ListVersionHandler extends ParseSax.HandlerWithResult<ListVersionsResponse> {
+   private Builder<ObjectMetadata> version = ImmutableSet.builder();
+   private Builder<String> commonPrefixes = ImmutableSet.builder();
+   private CanonicalUser currentOwner;
+   private StringBuilder currentText = new StringBuilder();
+
+   private ObjectMetadataBuilder builder = new ObjectMetadataBuilder();
+
+   private final DateService dateParser;
+
+   private String bucketName;
+   private String prefix;
+   private String marker;
+   private int maxResults;
+   private String delimiter;
+   private boolean isTruncated;
+   private boolean inCommonPrefixes;
+   private String currentKey;
+   private String nextMarker;
+
+   /** Some blobs have a non-hex suffix when created by multi-part uploads such Amazon S3. */
+   private static final Pattern ETAG_CONTENT_MD5_PATTERN = Pattern.compile("\"([0-9a-f]+)\"");
+
+   @Inject
+   public ListVersionHandler(DateService dateParser) {
+      this.dateParser = dateParser;
+   }
+
+   public ListVersionsResponse getResult() {
+      return new ListVersionsResponseImpl(bucketName, version.build(), prefix, marker,
+               (isTruncated && nextMarker == null) ? currentKey : nextMarker, maxResults, delimiter, isTruncated,
+               commonPrefixes.build());
+   }
+
+   public void startElement(String uri, String name, String qName, Attributes attrs) {
+      if (qName.equals("CommonPrefixes")) {
+         inCommonPrefixes = true;
+      }
+      currentText.setLength(0);
+   }
+
+   public void endElement(String uri, String name, String qName) {
+      if (qName.equals("ID")) {
+         currentOwner = new CanonicalUser(currentOrNull(currentText));
+      } else if (qName.equals("DisplayName")) {
+         currentOwner.setDisplayName(currentOrNull(currentText));
+      } else if (qName.equals("Key")) { // content stuff
+         if (currentText.length() == 0) {
+            throw new RuntimeException("Object store returned empty key name");
+         }
+         currentKey = currentText.toString();
+         builder.key(currentKey);
+         builder.uri(uriBuilder(getRequest().getEndpoint()).clearQuery().appendPath(Strings2.urlEncode(currentKey))
+               .build());
+      } else if (qName.equals("LastModified")) {
+         builder.lastModified(dateParser
+               .iso8601DateOrSecondsDateParse(currentOrNull(currentText)));
+      } else if (qName.equals("ETag")) {
+         String currentETag = currentOrNull(currentText);
+         builder.eTag(currentETag);
+         Matcher matcher = ETAG_CONTENT_MD5_PATTERN.matcher(currentETag);
+         if (matcher.matches()) {
+            builder.contentMD5(base16().lowerCase().decode(matcher.group(1)));
+         }
+      } else if (qName.equals("VersionId")) {
+         builder.versionId(currentOrNull(currentText));
+      } else if (qName.equals("IsLatest")) {
+         builder.isLatest(currentOrNull(currentText));
+      } else if (qName.equals("Size")) {
+         builder.contentLength(Long.valueOf(currentOrNull(currentText)));
+      } else if (qName.equals("Owner")) {
+         builder.owner(currentOwner);
+         currentOwner = null;
+      } else if (qName.equals("StorageClass")) {
+         builder.storageClass(ObjectMetadata.StorageClass.valueOf(currentOrNull(currentText)));
+      } else if (qName.equals("Version")) {
+         version.add(builder.build());
+         builder = new ObjectMetadataBuilder().bucket(bucketName);
+      } else if (qName.equals("Name")) {
+         this.bucketName = currentOrNull(currentText);
+         builder.bucket(bucketName);
+      } else if (qName.equals("Prefix")) {
+         String prefix = currentOrNull(currentText);
+         if (inCommonPrefixes)
+            commonPrefixes.add(prefix);
+         else
+            this.prefix = prefix;
+      } else if (qName.equals("Delimiter")) {
+         this.delimiter = currentOrNull(currentText);
+      } else if (qName.equals("Marker")) {
+         this.marker = currentOrNull(currentText);
+      } else if (qName.equals("NextMarker")) {
+         this.nextMarker = currentOrNull(currentText);
+      } else if (qName.equals("MaxKeys")) {
+         this.maxResults = Integer.parseInt(currentOrNull(currentText));
+      } else if (qName.equals("IsTruncated")) {
+         this.isTruncated = Boolean.parseBoolean(currentOrNull(currentText));
+      }
+   }
+
+   public void characters(char[] ch, int start, int length) {
+      currentText.append(ch, start, length);
+   }
+}

--- a/apis/s3/src/test/java/org/jclouds/s3/S3ClientTest.java
+++ b/apis/s3/src/test/java/org/jclouds/s3/S3ClientTest.java
@@ -60,11 +60,13 @@ import org.jclouds.s3.functions.ParseObjectFromHeadersAndHttpContent;
 import org.jclouds.s3.functions.ParseObjectMetadataFromHeaders;
 import org.jclouds.s3.functions.UploadIdFromHttpResponseViaRegex;
 import org.jclouds.s3.internal.BaseS3ClientTest;
+import org.jclouds.s3.options.BucketConfigOptions;
 import org.jclouds.s3.options.CopyObjectOptions;
 import org.jclouds.s3.options.ListBucketOptions;
 import org.jclouds.s3.options.PutBucketOptions;
 import org.jclouds.s3.options.PutObjectOptions;
 import org.jclouds.s3.xml.AccessControlListHandler;
+import org.jclouds.s3.xml.BucketConfigurationHandler;
 import org.jclouds.s3.xml.BucketLoggingHandler;
 import org.jclouds.s3.xml.CopyObjectHandler;
 import org.jclouds.s3.xml.ListAllMyBucketsHandler;
@@ -82,6 +84,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.reflect.Invokable;
 import com.google.inject.Module;
+
 /**
  * Tests behavior of {@code S3Client}
  */
@@ -500,6 +503,86 @@ public abstract class S3ClientTest<T extends S3Client> extends BaseS3ClientTest<
 
       checkFilters(request);
    }
+
+   public void testGetBucketVersion() throws SecurityException, NoSuchMethodException, IOException {
+      Invokable<?, ?> method = method(S3Client.class, "getBucketConfiguration", String.class, BucketConfigOptions[].class);
+      GeneratedHttpRequest request = processor.createRequest(method, ImmutableList.<Object> of("bucket", new BucketConfigOptions().versioning()));
+
+      assertRequestLineEquals(request, "GET https://bucket." + url + "/?versioning=true HTTP/1.1");
+      assertNonPayloadHeadersEqual(request, "Host: bucket." + url + "\n");
+      assertPayloadEquals(request, null, null, false);
+
+      assertResponseParserClassEquals(method, request, BucketConfigurationHandler.class);
+      assertSaxResponseParserClassEquals(method, null);
+      assertFallbackClassEquals(method, null);
+
+      checkFilters(request);
+   }
+
+   public void testGetBucketLifeCycles() throws SecurityException, NoSuchMethodException, IOException {
+      Invokable<?, ?> method = method(S3Client.class, "getBucketConfiguration", String.class, BucketConfigOptions[].class);
+      GeneratedHttpRequest request = processor.createRequest(method, ImmutableList.<Object> of("bucket", new BucketConfigOptions().lifecycle()));
+
+      assertRequestLineEquals(request, "GET https://bucket." + url + "/?lifecycle=true HTTP/1.1");
+      assertNonPayloadHeadersEqual(request, "Host: bucket." + url + "\n");
+      assertPayloadEquals(request, null, null, false);
+
+      assertResponseParserClassEquals(method, request, BucketConfigurationHandler.class);
+      assertSaxResponseParserClassEquals(method, null);
+      assertFallbackClassEquals(method, null);
+
+      checkFilters(request);
+   }
+
+   public void testGetBucketEncryption() throws SecurityException, NoSuchMethodException, IOException {
+      Invokable<?, ?> method = method(S3Client.class, "getBucketConfiguration", String.class, BucketConfigOptions[].class);
+      GeneratedHttpRequest request = processor.createRequest(method, ImmutableList.<Object> of("bucket", new BucketConfigOptions().encryption()));
+
+      assertRequestLineEquals(request, "GET https://bucket." + url + "/?encryption=true HTTP/1.1");
+      assertNonPayloadHeadersEqual(request, "Host: bucket." + url + "\n");
+      assertPayloadEquals(request, null, null, false);
+
+      assertResponseParserClassEquals(method, request, BucketConfigurationHandler.class);
+      assertSaxResponseParserClassEquals(method, null);
+      assertFallbackClassEquals(method, null);
+
+      checkFilters(request);
+   }
+
+   public void testDeleteBucketConfiguration() throws SecurityException, NoSuchMethodException, IOException {
+      Invokable<?, ?> method = method(S3Client.class, "deleteBucketConfiguration", String.class, BucketConfigOptions[].class);
+      GeneratedHttpRequest request = processor.createRequest(method, ImmutableList.<Object> of("bucket"));
+
+      assertRequestLineEquals(request, "DELETE https://bucket." + url + "/ HTTP/1.1");
+      assertNonPayloadHeadersEqual(request, "Host: bucket." + url + "\n");
+      assertPayloadEquals(request, null, null, false);
+
+      assertResponseParserClassEquals(method, request, BucketConfigurationHandler.class);
+      assertSaxResponseParserClassEquals(method, null);
+      assertFallbackClassEquals(method, MapHttp4xxCodesToExceptions.class);
+
+      checkFilters(request);
+   }
+
+   public void testPutBucketConfiguration() throws SecurityException, NoSuchMethodException, IOException {
+
+      Invokable<?, ?> method = method(S3Client.class, "putBucketConfiguration", String.class, S3Object.class,
+              BucketConfigOptions[].class);
+      GeneratedHttpRequest request = processor.createRequest(method, ImmutableList.<Object> of("bucket",
+              blobToS3Object.apply(BindBlobToMultipartFormTest.TEST_BLOB), new BucketConfigOptions().lifecycle()));
+
+      assertRequestLineEquals(request, "PUT https://bucket." + url + "/?lifecycle=true HTTP/1.1");
+      assertNonPayloadHeadersEqual(request, "Host: bucket." + url + "\n");
+      assertPayloadEquals(request, "hello", "text/plain",
+              false);
+
+      assertResponseParserClassEquals(method, request, BucketConfigurationHandler.class);
+      assertSaxResponseParserClassEquals(method, null);
+      assertFallbackClassEquals(method, null);
+
+      checkFilters(request);
+   }
+
 
    public void testEnableBucketLoggingOwner() throws SecurityException, NoSuchMethodException, IOException {
       Invokable<?, ?> method = method(S3Client.class, "enableBucketLogging", String.class, BucketLogging.class);

--- a/blobstore/src/main/java/org/jclouds/blobstore/domain/MutableBlobMetadata.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/domain/MutableBlobMetadata.java
@@ -51,4 +51,6 @@ public interface MutableBlobMetadata extends BlobMetadata, MutableStorageMetadat
    void setContainer(@Nullable String container);
 
    void setTier(Tier tier);
+
+   void setVersionId(String versionId);
 }

--- a/blobstore/src/main/java/org/jclouds/blobstore/domain/MutableStorageMetadata.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/domain/MutableStorageMetadata.java
@@ -50,4 +50,8 @@ public interface MutableStorageMetadata extends MutableResourceMetadata<StorageT
    void setSize(@Nullable Long size);
 
    void setTier(Tier tier);
+
+   void setVersionId(String versionId);
+
+   void setIsLatest(String isLatest);
 }

--- a/blobstore/src/main/java/org/jclouds/blobstore/domain/StorageMetadata.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/domain/StorageMetadata.java
@@ -78,6 +78,9 @@ public interface StorageMetadata extends ResourceMetadata<StorageType> {
     */
    String getETag();
 
+   /**
+    * Version Id of the resource.
+    */
    String getVersionId();
 
    String getIsLatest();

--- a/blobstore/src/main/java/org/jclouds/blobstore/domain/StorageMetadata.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/domain/StorageMetadata.java
@@ -78,6 +78,10 @@ public interface StorageMetadata extends ResourceMetadata<StorageType> {
     */
    String getETag();
 
+   String getVersionId();
+
+   String getIsLatest();
+
    /**
     * Creation date of the resource, possibly null.
     */

--- a/blobstore/src/main/java/org/jclouds/blobstore/domain/internal/MutableBlobMetadataImpl.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/domain/internal/MutableBlobMetadataImpl.java
@@ -18,17 +18,17 @@ package org.jclouds.blobstore.domain.internal;
 
 import java.net.URI;
 
-import com.google.common.base.MoreObjects.ToStringHelper;
 import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects.ToStringHelper;
 
 import org.jclouds.blobstore.domain.BlobMetadata;
 import org.jclouds.blobstore.domain.MutableBlobMetadata;
 import org.jclouds.blobstore.domain.StorageType;
 import org.jclouds.blobstore.domain.Tier;
-import org.jclouds.domain.ResourceMetadata;
 import org.jclouds.http.HttpUtils;
 import org.jclouds.io.MutableContentMetadata;
 import org.jclouds.io.payloads.BaseMutableContentMetadata;
+import org.jclouds.domain.ResourceMetadata;
 
 /**
  * System and user Metadata for the {@link Blob}.

--- a/blobstore/src/main/java/org/jclouds/blobstore/domain/internal/MutableBlobMetadataImpl.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/domain/internal/MutableBlobMetadataImpl.java
@@ -114,7 +114,7 @@ public class MutableBlobMetadataImpl extends MutableStorageMetadataImpl implemen
 
    @Override
    public int compareTo(ResourceMetadata<StorageType> o) {
-      return (this == o) ? 0 : (this.equals(o))? 0 : (this.hashCode()-o.hashCode());
+      return super.compareTo(o);
    }
 
    @Override

--- a/blobstore/src/main/java/org/jclouds/blobstore/domain/internal/MutableBlobMetadataImpl.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/domain/internal/MutableBlobMetadataImpl.java
@@ -18,13 +18,14 @@ package org.jclouds.blobstore.domain.internal;
 
 import java.net.URI;
 
-import com.google.common.base.Objects;
 import com.google.common.base.MoreObjects.ToStringHelper;
+import com.google.common.base.Objects;
 
 import org.jclouds.blobstore.domain.BlobMetadata;
 import org.jclouds.blobstore.domain.MutableBlobMetadata;
 import org.jclouds.blobstore.domain.StorageType;
 import org.jclouds.blobstore.domain.Tier;
+import org.jclouds.domain.ResourceMetadata;
 import org.jclouds.http.HttpUtils;
 import org.jclouds.io.MutableContentMetadata;
 import org.jclouds.io.payloads.BaseMutableContentMetadata;
@@ -109,6 +110,11 @@ public class MutableBlobMetadataImpl extends MutableStorageMetadataImpl implemen
    @Override
    public void setTier(Tier tier) {
       this.tier = tier;
+   }
+
+   @Override
+   public int compareTo(ResourceMetadata<StorageType> o) {
+      return (this == o) ? 0 : (this.equals(o))? 0 : (this.hashCode()-o.hashCode());
    }
 
    @Override

--- a/blobstore/src/main/java/org/jclouds/blobstore/domain/internal/MutableStorageMetadataImpl.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/domain/internal/MutableStorageMetadataImpl.java
@@ -18,8 +18,8 @@ package org.jclouds.blobstore.domain.internal;
 
 import java.util.Date;
 
-import com.google.common.base.MoreObjects.ToStringHelper;
 import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects.ToStringHelper;
 
 import org.jclouds.blobstore.domain.MutableStorageMetadata;
 import org.jclouds.blobstore.domain.StorageMetadata;
@@ -114,7 +114,7 @@ public class MutableStorageMetadataImpl extends MutableResourceMetadataImpl<Stor
 
    @Override
    public void setIsLatest(String isLatest) {
-   this.isLatest = isLatest;
+      this.isLatest = isLatest;
    }
 
    @Override

--- a/blobstore/src/main/java/org/jclouds/blobstore/domain/internal/MutableStorageMetadataImpl.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/domain/internal/MutableStorageMetadataImpl.java
@@ -18,8 +18,8 @@ package org.jclouds.blobstore.domain.internal;
 
 import java.util.Date;
 
-import com.google.common.base.Objects;
 import com.google.common.base.MoreObjects.ToStringHelper;
+import com.google.common.base.Objects;
 
 import org.jclouds.blobstore.domain.MutableStorageMetadata;
 import org.jclouds.blobstore.domain.StorageMetadata;
@@ -38,6 +38,8 @@ public class MutableStorageMetadataImpl extends MutableResourceMetadataImpl<Stor
    private Date lastModified;
    private Long size;
    private Tier tier;
+   private String versionId;
+   private String isLatest;
 
    public MutableStorageMetadataImpl() {
       super();
@@ -49,6 +51,8 @@ public class MutableStorageMetadataImpl extends MutableResourceMetadataImpl<Stor
       this.lastModified = from.getLastModified();
       this.size = from.getSize();
       this.tier = from.getTier();
+      this.versionId = from.getVersionId();
+      this.isLatest = from.getIsLatest();
    }
 
    /**
@@ -57,6 +61,16 @@ public class MutableStorageMetadataImpl extends MutableResourceMetadataImpl<Stor
    @Override
    public String getETag() {
       return eTag;
+   }
+
+   @Override
+   public String getVersionId() {
+      return versionId;
+   }
+
+   @Override
+   public String getIsLatest() {
+      return isLatest;
    }
 
    @Override
@@ -94,6 +108,16 @@ public class MutableStorageMetadataImpl extends MutableResourceMetadataImpl<Stor
    }
 
    @Override
+   public void setVersionId(String versionId) {
+      this.versionId = versionId;
+   }
+
+   @Override
+   public void setIsLatest(String isLatest) {
+   this.isLatest = isLatest;
+   }
+
+   @Override
    public Long getSize() {
       return size;
    }
@@ -124,6 +148,8 @@ public class MutableStorageMetadataImpl extends MutableResourceMetadataImpl<Stor
       MutableStorageMetadataImpl that = (MutableStorageMetadataImpl) object;
       return super.equals(that) &&
             Objects.equal(eTag, that.eTag) &&
+            Objects.equal(versionId, that.versionId) &&
+            Objects.equal(isLatest, that.isLatest) &&
             Objects.equal(creationDate, that.creationDate) &&
             Objects.equal(lastModified, that.lastModified) &&
             Objects.equal(size, that.size) &&
@@ -132,13 +158,14 @@ public class MutableStorageMetadataImpl extends MutableResourceMetadataImpl<Stor
 
    @Override
    public int hashCode() {
-      return Objects.hashCode(super.hashCode(), eTag, creationDate, lastModified, size, tier);
+      return Objects.hashCode(super.hashCode(), eTag, versionId, isLatest, creationDate, lastModified, size, tier);
    }
 
    @Override
    protected ToStringHelper string() {
       return super.string()
             .add("eTag", eTag)
+            .add("versionId", versionId)
             .add("creationDate", creationDate)
             .add("lastModified", lastModified)
             .add("size", size)

--- a/blobstore/src/main/java/org/jclouds/blobstore/domain/internal/StorageMetadataImpl.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/domain/internal/StorageMetadataImpl.java
@@ -22,8 +22,8 @@ import java.net.URI;
 import java.util.Date;
 import java.util.Map;
 
-import com.google.common.base.MoreObjects.ToStringHelper;
 import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects.ToStringHelper;
 
 import org.jclouds.blobstore.domain.StorageMetadata;
 import org.jclouds.blobstore.domain.StorageType;
@@ -54,9 +54,9 @@ public class StorageMetadataImpl extends ResourceMetadataImpl<StorageType> imple
    private final Tier tier;
 
    public StorageMetadataImpl(StorageType type, @Nullable String id, @Nullable String name,
-                              @Nullable Location location, @Nullable URI uri, @Nullable String eTag,
-                              @Nullable Date creationDate, @Nullable Date lastModified,
-                              Map<String, String> userMetadata, @Nullable Long size, Tier tier) {
+         @Nullable Location location, @Nullable URI uri, @Nullable String eTag,
+         @Nullable Date creationDate, @Nullable Date lastModified,
+         Map<String, String> userMetadata, @Nullable Long size, Tier tier) {
       super(id, name, location, uri, userMetadata);
       this.eTag = eTag;
       this.creationDate = creationDate;
@@ -69,9 +69,9 @@ public class StorageMetadataImpl extends ResourceMetadataImpl<StorageType> imple
    }
 
    public StorageMetadataImpl(StorageType type, @Nullable String id, @Nullable String name,
-                              @Nullable Location location, @Nullable URI uri, @Nullable String eTag,
-                              @Nullable Date creationDate, @Nullable Date lastModified,
-                              Map<String, String> userMetadata, @Nullable Long size, Tier tier, @Nullable String versionId) {
+         @Nullable Location location, @Nullable URI uri, @Nullable String eTag,
+         @Nullable Date creationDate, @Nullable Date lastModified,
+         Map<String, String> userMetadata, @Nullable Long size, Tier tier, @Nullable String versionId) {
       super(id, name, location, uri, userMetadata);
       this.eTag = eTag;
       this.creationDate = creationDate;
@@ -86,18 +86,18 @@ public class StorageMetadataImpl extends ResourceMetadataImpl<StorageType> imple
    /** @deprecated call StorageMetadataImpl(StorageType.class, String.class, String.class, Location.class, URI.class, String.class, Date.class, Date.class, Map.class, Long.class, Tier.class) */
    @Deprecated
    public StorageMetadataImpl(StorageType type, @Nullable String id, @Nullable String name,
-                              @Nullable Location location, @Nullable URI uri, @Nullable String eTag,
-                              @Nullable Date creationDate, @Nullable Date lastModified,
-                              Map<String, String> userMetadata, @Nullable Long size) {
+         @Nullable Location location, @Nullable URI uri, @Nullable String eTag,
+         @Nullable Date creationDate, @Nullable Date lastModified,
+         Map<String, String> userMetadata, @Nullable Long size) {
       this(type, id, name, location, uri, eTag, creationDate, lastModified, userMetadata, size, null);
    }
 
    /** @deprecated call StorageMetadataImpl(StorageType.class, String.class, String.class, Location.class, URI.class, String.class, Date.class, Date.class, Map.class, Long.class) */
    @Deprecated
    public StorageMetadataImpl(StorageType type, @Nullable String id, @Nullable String name,
-                              @Nullable Location location, @Nullable URI uri, @Nullable String eTag,
-                              @Nullable Date creationDate, @Nullable Date lastModified,
-                              Map<String, String> userMetadata) {
+         @Nullable Location location, @Nullable URI uri, @Nullable String eTag,
+         @Nullable Date creationDate, @Nullable Date lastModified,
+         Map<String, String> userMetadata) {
       this(type, id, name, location, uri, eTag, creationDate, lastModified, userMetadata, null);
    }
 

--- a/blobstore/src/main/java/org/jclouds/blobstore/domain/internal/StorageMetadataImpl.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/domain/internal/StorageMetadataImpl.java
@@ -22,8 +22,8 @@ import java.net.URI;
 import java.util.Date;
 import java.util.Map;
 
-import com.google.common.base.Objects;
 import com.google.common.base.MoreObjects.ToStringHelper;
+import com.google.common.base.Objects;
 
 import org.jclouds.blobstore.domain.StorageMetadata;
 import org.jclouds.blobstore.domain.StorageType;
@@ -40,6 +40,10 @@ public class StorageMetadataImpl extends ResourceMetadataImpl<StorageType> imple
    @Nullable
    private final String eTag;
    @Nullable
+   private final String versionId;
+   @Nullable
+   private final String isLatest;
+   @Nullable
    private final Date creationDate;
    @Nullable
    private final Date lastModified;
@@ -50,9 +54,9 @@ public class StorageMetadataImpl extends ResourceMetadataImpl<StorageType> imple
    private final Tier tier;
 
    public StorageMetadataImpl(StorageType type, @Nullable String id, @Nullable String name,
-         @Nullable Location location, @Nullable URI uri, @Nullable String eTag,
-         @Nullable Date creationDate, @Nullable Date lastModified,
-         Map<String, String> userMetadata, @Nullable Long size, Tier tier) {
+                              @Nullable Location location, @Nullable URI uri, @Nullable String eTag,
+                              @Nullable Date creationDate, @Nullable Date lastModified,
+                              Map<String, String> userMetadata, @Nullable Long size, Tier tier) {
       super(id, name, location, uri, userMetadata);
       this.eTag = eTag;
       this.creationDate = creationDate;
@@ -60,23 +64,40 @@ public class StorageMetadataImpl extends ResourceMetadataImpl<StorageType> imple
       this.type = checkNotNull(type, "type");
       this.size = size;
       this.tier = tier;
+      this.versionId = null;
+      this.isLatest= null;
+   }
+
+   public StorageMetadataImpl(StorageType type, @Nullable String id, @Nullable String name,
+                              @Nullable Location location, @Nullable URI uri, @Nullable String eTag,
+                              @Nullable Date creationDate, @Nullable Date lastModified,
+                              Map<String, String> userMetadata, @Nullable Long size, Tier tier, @Nullable String versionId) {
+      super(id, name, location, uri, userMetadata);
+      this.eTag = eTag;
+      this.creationDate = creationDate;
+      this.lastModified = lastModified;
+      this.type = checkNotNull(type, "type");
+      this.size = size;
+      this.tier = tier;
+      this.versionId = versionId;
+      this.isLatest= null;
    }
 
    /** @deprecated call StorageMetadataImpl(StorageType.class, String.class, String.class, Location.class, URI.class, String.class, Date.class, Date.class, Map.class, Long.class, Tier.class) */
    @Deprecated
    public StorageMetadataImpl(StorageType type, @Nullable String id, @Nullable String name,
-         @Nullable Location location, @Nullable URI uri, @Nullable String eTag,
-         @Nullable Date creationDate, @Nullable Date lastModified,
-         Map<String, String> userMetadata, @Nullable Long size) {
+                              @Nullable Location location, @Nullable URI uri, @Nullable String eTag,
+                              @Nullable Date creationDate, @Nullable Date lastModified,
+                              Map<String, String> userMetadata, @Nullable Long size) {
       this(type, id, name, location, uri, eTag, creationDate, lastModified, userMetadata, size, null);
    }
 
    /** @deprecated call StorageMetadataImpl(StorageType.class, String.class, String.class, Location.class, URI.class, String.class, Date.class, Date.class, Map.class, Long.class) */
    @Deprecated
    public StorageMetadataImpl(StorageType type, @Nullable String id, @Nullable String name,
-         @Nullable Location location, @Nullable URI uri, @Nullable String eTag,
-         @Nullable Date creationDate, @Nullable Date lastModified,
-         Map<String, String> userMetadata) {
+                              @Nullable Location location, @Nullable URI uri, @Nullable String eTag,
+                              @Nullable Date creationDate, @Nullable Date lastModified,
+                              Map<String, String> userMetadata) {
       this(type, id, name, location, uri, eTag, creationDate, lastModified, userMetadata, null);
    }
 
@@ -90,7 +111,7 @@ public class StorageMetadataImpl extends ResourceMetadataImpl<StorageType> imple
 
    @Override
    public int hashCode() {
-      return Objects.hashCode(super.hashCode(), eTag, creationDate,
+      return Objects.hashCode(super.hashCode(), eTag, versionId, creationDate,
             lastModified, type, size, tier);
    }
 
@@ -104,6 +125,7 @@ public class StorageMetadataImpl extends ResourceMetadataImpl<StorageType> imple
          return false;
       StorageMetadataImpl other = (StorageMetadataImpl) obj;
       if (!Objects.equal(eTag, other.eTag)) { return false; }
+      if (!Objects.equal(versionId, other.versionId)) { return false; }
       if (!Objects.equal(creationDate, other.creationDate)) { return false; }
       if (!Objects.equal(lastModified, other.lastModified)) { return false; }
       if (!Objects.equal(type, other.type)) { return false; }
@@ -116,6 +138,7 @@ public class StorageMetadataImpl extends ResourceMetadataImpl<StorageType> imple
    protected ToStringHelper string() {
       return super.string()
             .add("eTag", eTag)
+            .add("versionId", versionId)
             .add("creationDate", creationDate)
             .add("lastModified", lastModified)
             .add("type", type)
@@ -129,6 +152,16 @@ public class StorageMetadataImpl extends ResourceMetadataImpl<StorageType> imple
    @Override
    public String getETag() {
       return eTag;
+   }
+
+   @Override
+   public String getVersionId() {
+      return versionId;
+   }
+
+   @Override
+   public String getIsLatest() {
+      return isLatest;
    }
 
    @Override

--- a/blobstore/src/main/java/org/jclouds/blobstore/domain/internal/StorageMetadataImpl.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/domain/internal/StorageMetadataImpl.java
@@ -65,7 +65,7 @@ public class StorageMetadataImpl extends ResourceMetadataImpl<StorageType> imple
       this.size = size;
       this.tier = tier;
       this.versionId = null;
-      this.isLatest= null;
+      this.isLatest = null;
    }
 
    public StorageMetadataImpl(StorageType type, @Nullable String id, @Nullable String name,
@@ -80,7 +80,7 @@ public class StorageMetadataImpl extends ResourceMetadataImpl<StorageType> imple
       this.size = size;
       this.tier = tier;
       this.versionId = versionId;
-      this.isLatest= null;
+      this.isLatest = null;
    }
 
    /** @deprecated call StorageMetadataImpl(StorageType.class, String.class, String.class, Location.class, URI.class, String.class, Date.class, Date.class, Map.class, Long.class, Tier.class) */

--- a/blobstore/src/main/java/org/jclouds/blobstore/functions/BlobToHttpGetOptions.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/functions/BlobToHttpGetOptions.java
@@ -20,9 +20,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import javax.inject.Singleton;
 
-import org.jclouds.http.options.GetOptions;
-
 import com.google.common.base.Function;
+
+import org.jclouds.http.options.GetOptions;
 
 @Singleton
 public class BlobToHttpGetOptions implements Function<org.jclouds.blobstore.options.GetOptions, GetOptions> {
@@ -53,6 +53,9 @@ public class BlobToHttpGetOptions implements Function<org.jclouds.blobstore.opti
             httpOptions.tail(Long.parseLong(firstLast[1]));
          else
             httpOptions.startAt(Long.parseLong(firstLast[0]));
+      }
+      if (from.getVersionId() != null) {
+         httpOptions.versionId(from.getVersionId());
       }
       return httpOptions;
    }

--- a/blobstore/src/main/java/org/jclouds/blobstore/functions/BlobToHttpGetOptions.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/functions/BlobToHttpGetOptions.java
@@ -20,9 +20,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import javax.inject.Singleton;
 
-import com.google.common.base.Function;
-
 import org.jclouds.http.options.GetOptions;
+
+import com.google.common.base.Function;
 
 @Singleton
 public class BlobToHttpGetOptions implements Function<org.jclouds.blobstore.options.GetOptions, GetOptions> {

--- a/blobstore/src/main/java/org/jclouds/blobstore/functions/ParseSystemAndUserMetadataFromHeaders.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/functions/ParseSystemAndUserMetadataFromHeaders.java
@@ -29,10 +29,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Function;
-import com.google.common.net.HttpHeaders;
-
 import org.jclouds.blobstore.domain.MutableBlobMetadata;
 import org.jclouds.date.DateService;
 import org.jclouds.http.HttpException;
@@ -41,6 +37,10 @@ import org.jclouds.http.HttpResponse;
 import org.jclouds.http.HttpUtils;
 import org.jclouds.rest.InvocationContext;
 import org.jclouds.rest.internal.GeneratedHttpRequest;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Function;
+import com.google.common.net.HttpHeaders;
 
 public class ParseSystemAndUserMetadataFromHeaders implements Function<HttpResponse, MutableBlobMetadata>,
          InvocationContext<ParseSystemAndUserMetadataFromHeaders> {
@@ -53,7 +53,7 @@ public class ParseSystemAndUserMetadataFromHeaders implements Function<HttpRespo
 
    @Inject
    public ParseSystemAndUserMetadataFromHeaders(Provider<MutableBlobMetadata> metadataFactory, DateService dateParser,
-                                                @Named(PROPERTY_USER_METADATA_PREFIX) String metadataPrefix) {
+            @Named(PROPERTY_USER_METADATA_PREFIX) String metadataPrefix) {
       this.metadataFactory = checkNotNull(metadataFactory, "metadataFactory");
       this.dateParser = checkNotNull(dateParser, "dateParser");
       this.metadataPrefix = checkNotNull(metadataPrefix, "metadataPrefix").toLowerCase();
@@ -112,10 +112,10 @@ public class ParseSystemAndUserMetadataFromHeaders implements Function<HttpRespo
    }
 
    protected void addVersionIdTo(HttpResponse from, MutableBlobMetadata metadata) {
-      String versionId = from.getFirstHeaderOrNull("x-amz-version-id");
-      if (metadata.getVersionId() == null && versionId != null) {
-         metadata.setVersionId(versionId);
-      }
+	  String versionId = from.getFirstHeaderOrNull("x-amz-version-id");
+	  if (metadata.getVersionId() == null && versionId != null) {
+	     metadata.setVersionId(versionId);
+	  }
    }
 
    public ParseSystemAndUserMetadataFromHeaders setContext(HttpRequest request) {

--- a/blobstore/src/main/java/org/jclouds/blobstore/functions/ParseSystemAndUserMetadataFromHeaders.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/functions/ParseSystemAndUserMetadataFromHeaders.java
@@ -71,7 +71,7 @@ public class ParseSystemAndUserMetadataFromHeaders implements Function<HttpRespo
       addETagTo(from, to);
       parseLastModifiedOrThrowException(from, to);
       addUserMetadataTo(from, to);
-      addVersionIdTo(from,to);
+      addVersionIdTo(from, to);
       return to;
    }
 

--- a/blobstore/src/main/java/org/jclouds/blobstore/options/GetOptions.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/options/GetOptions.java
@@ -89,6 +89,7 @@ public class GetOptions {
    public String getVersionId() {
       return this.versionId;
    }
+
    /**
     * Only return the object if it has changed since this time.
     * <p />

--- a/blobstore/src/main/java/org/jclouds/blobstore/options/GetOptions.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/options/GetOptions.java
@@ -47,6 +47,7 @@ public class GetOptions {
    private Date ifUnmodifiedSince;
    private String ifMatch;
    private String ifNoneMatch;
+   private String versionId;
 
    /**
     * download the specified range of the object.
@@ -80,6 +81,14 @@ public class GetOptions {
       return this;
    }
 
+   public GetOptions versionId(String versionId) {
+      this.versionId = checkNotNull(versionId, "versionId");
+      return this;
+   }
+
+   public String getVersionId() {
+      return this.versionId;
+   }
    /**
     * Only return the object if it has changed since this time.
     * <p />

--- a/blobstore/src/main/java/org/jclouds/blobstore/options/ListContainerOptions.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/options/ListContainerOptions.java
@@ -44,18 +44,24 @@ public class ListContainerOptions extends ListOptions implements Cloneable {
    private String prefix;
    private boolean recursive;
    private boolean detailed;
+   private boolean versions;
 
    public ListContainerOptions() {
    }
 
    ListContainerOptions(Integer maxKeys, String marker, String dir, boolean recursive,
-            boolean detailed, String prefix, String delimiter) {
+                        boolean detailed, String prefix, String delimiter) {
       super(maxKeys, marker);
       this.dir = dir;
       this.recursive = recursive;
       this.detailed = detailed;
       this.prefix = prefix;
       this.delimiter = delimiter;
+   }
+   ListContainerOptions(Integer maxKeys, String marker, String dir, boolean recursive,
+                        boolean detailed, String prefix, String delimiter, boolean versions) {
+      this(maxKeys, marker, dir, recursive, detailed, prefix, delimiter);
+      this.versions = versions;
    }
 
    public static class ImmutableListContainerOptions extends ListContainerOptions {
@@ -89,6 +95,12 @@ public class ListContainerOptions extends ListOptions implements Cloneable {
       public boolean isRecursive() {
          return delegate.isRecursive();
       }
+
+      @Override
+      public boolean isVersions() {
+         return delegate.isVersions();
+      }
+
 
       @Override
       public ListContainerOptions maxResults(int maxKeys) {
@@ -163,6 +175,8 @@ public class ListContainerOptions extends ListOptions implements Cloneable {
       return detailed;
    }
 
+   public boolean isVersions() { return versions; }
+
    public String getPrefix() {
       return prefix;
    }
@@ -231,6 +245,15 @@ public class ListContainerOptions extends ListOptions implements Cloneable {
       return this;
    }
 
+   /**
+    * return a listing of all objects inside the store, recursively.
+    */
+   public ListContainerOptions versions() {
+      // checkArgument(path == null, "path and recursive combination currently not supported");
+      this.versions = true;
+      return this;
+   }
+
    public static class Builder {
 
       /**
@@ -268,6 +291,13 @@ public class ListContainerOptions extends ListOptions implements Cloneable {
       }
 
       /**
+       * @see ListContainerOptions#versions()
+       */
+      public static ListContainerOptions versions() {
+         ListContainerOptions options = new ListContainerOptions();
+         return options.versions();
+      }
+      /**
        * @see ListContainerOptions#withDetails()
        */
       public static ListContainerOptions withDetails() {
@@ -293,7 +323,7 @@ public class ListContainerOptions extends ListOptions implements Cloneable {
 
    @Override
    public ListContainerOptions clone() {
-      return new ListContainerOptions(getMaxResults(), getMarker(), dir, recursive, detailed, prefix, delimiter);
+      return new ListContainerOptions(getMaxResults(), getMarker(), dir, recursive, detailed, prefix, delimiter, versions);
    }
 
    @Override
@@ -301,12 +331,13 @@ public class ListContainerOptions extends ListOptions implements Cloneable {
       return "[dir=" + dir + ", recursive=" + recursive + ", detailed=" + detailed
                + ", prefix=" + prefix + ", marker=" + getMarker()
                + ", delimiter=" + delimiter
-               + ", maxResults=" + getMaxResults() + "]";
+               + ", maxResults=" + getMaxResults()
+               + ", versions=" + versions+ "]";
    }
 
    @Override
    public int hashCode() {
-      return Objects.hashCode(detailed, recursive, dir, getMarker(), getMaxResults());
+      return Objects.hashCode(detailed, recursive, dir, getMarker(), getMaxResults(),versions);
    }
 
    @Override
@@ -320,6 +351,7 @@ public class ListContainerOptions extends ListOptions implements Cloneable {
       ListContainerOptions other = (ListContainerOptions) obj;
       return (detailed == other.detailed) &&
                recursive == other.recursive &&
+               versions == other.versions &&
                Objects.equal(dir, other.dir) &&
                Objects.equal(prefix, other.prefix) &&
                Objects.equal(getMarker(), other.getMarker()) &&

--- a/blobstore/src/main/java/org/jclouds/blobstore/options/ListContainerOptions.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/options/ListContainerOptions.java
@@ -214,7 +214,6 @@ public class ListContainerOptions extends ListOptions implements Cloneable {
     * return a listing of all objects inside the store, recursively.
     */
    public ListContainerOptions recursive() {
-      // checkArgument(path == null, "path and recursive combination currently not supported");
       this.recursive = true;
       return this;
    }

--- a/blobstore/src/main/java/org/jclouds/blobstore/options/ListContainerOptions.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/options/ListContainerOptions.java
@@ -332,12 +332,12 @@ public class ListContainerOptions extends ListOptions implements Cloneable {
                + ", prefix=" + prefix + ", marker=" + getMarker()
                + ", delimiter=" + delimiter
                + ", maxResults=" + getMaxResults()
-               + ", versions=" + versions+ "]";
+               + ", versions=" + versions + "]";
    }
 
    @Override
    public int hashCode() {
-      return Objects.hashCode(detailed, recursive, dir, getMarker(), getMaxResults(),versions);
+      return Objects.hashCode(detailed, recursive, dir, getMarker(), getMaxResults(), versions);
    }
 
    @Override

--- a/blobstore/src/main/java/org/jclouds/blobstore/options/ListContainerOptions.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/options/ListContainerOptions.java
@@ -50,7 +50,7 @@ public class ListContainerOptions extends ListOptions implements Cloneable {
    }
 
    ListContainerOptions(Integer maxKeys, String marker, String dir, boolean recursive,
-                        boolean detailed, String prefix, String delimiter) {
+            boolean detailed, String prefix, String delimiter) {
       super(maxKeys, marker);
       this.dir = dir;
       this.recursive = recursive;
@@ -58,8 +58,9 @@ public class ListContainerOptions extends ListOptions implements Cloneable {
       this.prefix = prefix;
       this.delimiter = delimiter;
    }
+
    ListContainerOptions(Integer maxKeys, String marker, String dir, boolean recursive,
-                        boolean detailed, String prefix, String delimiter, boolean versions) {
+            boolean detailed, String prefix, String delimiter, boolean versions) {
       this(maxKeys, marker, dir, recursive, detailed, prefix, delimiter);
       this.versions = versions;
    }
@@ -100,7 +101,6 @@ public class ListContainerOptions extends ListOptions implements Cloneable {
       public boolean isVersions() {
          return delegate.isVersions();
       }
-
 
       @Override
       public ListContainerOptions maxResults(int maxKeys) {
@@ -175,7 +175,9 @@ public class ListContainerOptions extends ListOptions implements Cloneable {
       return detailed;
    }
 
-   public boolean isVersions() { return versions; }
+   public boolean isVersions() {
+      return versions;
+   }
 
    public String getPrefix() {
       return prefix;
@@ -214,6 +216,7 @@ public class ListContainerOptions extends ListOptions implements Cloneable {
     * return a listing of all objects inside the store, recursively.
     */
    public ListContainerOptions recursive() {
+      // checkArgument(path == null, "path and recursive combination currently not supported");
       this.recursive = true;
       return this;
    }
@@ -248,7 +251,6 @@ public class ListContainerOptions extends ListOptions implements Cloneable {
     * return a listing of all objects inside the store, recursively.
     */
    public ListContainerOptions versions() {
-      // checkArgument(path == null, "path and recursive combination currently not supported");
       this.versions = true;
       return this;
    }
@@ -296,6 +298,7 @@ public class ListContainerOptions extends ListOptions implements Cloneable {
          ListContainerOptions options = new ListContainerOptions();
          return options.versions();
       }
+
       /**
        * @see ListContainerOptions#withDetails()
        */

--- a/core/src/main/java/org/jclouds/http/options/GetOptions.java
+++ b/core/src/main/java/org/jclouds/http/options/GetOptions.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 package org.jclouds.http.options;
+
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.net.HttpHeaders.IF_MATCH;
@@ -26,12 +27,12 @@ import static com.google.common.net.HttpHeaders.RANGE;
 import java.util.Date;
 import java.util.List;
 
-import org.jclouds.date.DateService;
-import org.jclouds.date.internal.SimpleDateFormatDateService;
-
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
+
+import org.jclouds.date.DateService;
+import org.jclouds.date.internal.SimpleDateFormatDateService;
 
 /**
  * Contains options supported for HTTP GET operations. <h2>
@@ -99,6 +100,15 @@ public class GetOptions extends BaseHttpRequestOptions {
       return (!ranges.isEmpty()) ? String.format("bytes=%s", Joiner.on(",").join(ranges)) : null;
    }
 
+   public GetOptions versionId(String versionId) {
+      this.queryParameters.put("versionId",
+          checkNotNull(versionId, "versionId"));
+      return this;
+   }
+
+   public String getVersionId() {
+      return this.getVersionId();
+   }
    /**
     * Only return the object if it has changed since this time.
     * <p />
@@ -232,6 +242,11 @@ public class GetOptions extends BaseHttpRequestOptions {
       public static GetOptions tail(long count) {
          GetOptions options = new GetOptions();
          return options.tail(count);
+      }
+
+      public static GetOptions versionId(String versionId) {
+         GetOptions options = new GetOptions();
+         return options.versionId(versionId);
       }
 
       /**

--- a/core/src/main/java/org/jclouds/http/options/GetOptions.java
+++ b/core/src/main/java/org/jclouds/http/options/GetOptions.java
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 package org.jclouds.http.options;
-
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.net.HttpHeaders.IF_MATCH;
@@ -27,12 +26,12 @@ import static com.google.common.net.HttpHeaders.RANGE;
 import java.util.Date;
 import java.util.List;
 
+import org.jclouds.date.DateService;
+import org.jclouds.date.internal.SimpleDateFormatDateService;
+
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
-
-import org.jclouds.date.DateService;
-import org.jclouds.date.internal.SimpleDateFormatDateService;
 
 /**
  * Contains options supported for HTTP GET operations. <h2>
@@ -102,13 +101,14 @@ public class GetOptions extends BaseHttpRequestOptions {
 
    public GetOptions versionId(String versionId) {
       this.queryParameters.put("versionId",
-          checkNotNull(versionId, "versionId"));
+            checkNotNull(versionId, "versionId"));
       return this;
    }
 
    public String getVersionId() {
       return this.getVersionId();
    }
+
    /**
     * Only return the object if it has changed since this time.
     * <p />
@@ -244,6 +244,9 @@ public class GetOptions extends BaseHttpRequestOptions {
          return options.tail(count);
       }
 
+      /**
+       * @see GetOptions#versionId(String)
+       */
       public static GetOptions versionId(String versionId) {
          GetOptions options = new GetOptions();
          return options.versionId(versionId);


### PR DESCRIPTION
Changes included in - https://issues.apache.org/jira/browse/JCLOUDS-1587 after removing noise changes.

Support following features in jclouds s3 blobstore

Configure the bucket for versioning and get the versioning state of a bucket
Configure the bucket for encryption and get the encryption state of a bucket
Configure the bucket for lifecycle rules and get the lifecycle rules of a bucket
List different versions of an Object