### PR TITLE
Upgrade to assertj 3.23.1

### DIFF
--- a/apis/glacier/src/test/java/org/jclouds/glacier/GlacierClientLiveTest.java
+++ b/apis/glacier/src/test/java/org/jclouds/glacier/GlacierClientLiveTest.java
@@ -88,7 +88,7 @@ public class GlacierClientLiveTest extends BaseApiLiveTest<GlacierClient> {
                ContentRange.fromPartNumber(1, partSizeInMb), buildPayload(partSizeInMb * MiB));
          assertThat(part1).isNotNull();
          assertThat(part2).isNotNull();
-         assertThat(api.listParts(VAULT_NAME1, uploadId).iterator()).extracting("treeHash").containsExactly(part1, part2);
+         assertThat(api.listParts(VAULT_NAME1, uploadId).iterator()).toIterable().extracting("treeHash").containsExactly(part1, part2);
       } finally {
          assertThat(api.abortMultipartUpload(VAULT_NAME1, uploadId)).isTrue();
       }

--- a/apis/glacier/src/test/java/org/jclouds/glacier/GlacierClientMockTest.java
+++ b/apis/glacier/src/test/java/org/jclouds/glacier/GlacierClientMockTest.java
@@ -351,8 +351,8 @@ public class GlacierClientMockTest {
       assertThat(mpu.getArchiveDescription()).isEqualTo("archive description 1");
       assertThat(mpu.getMultipartUploadId()).isEqualTo(MULTIPART_UPLOAD_ID);
       assertThat(mpu.getPartSizeInBytes()).isEqualTo(4194304);
-      assertThat(mpu.iterator()).extracting("treeHash").containsExactly(HashCode.fromString("01d34dabf7be316472c93b1ef80721f5d4"));
-      assertThat(mpu.iterator()).extracting("range").containsExactly(ContentRange.fromString("4194304-8388607"));
+      assertThat(mpu.iterator()).toIterable().extracting("treeHash").containsExactly(HashCode.fromString("01d34dabf7be316472c93b1ef80721f5d4"));
+      assertThat(mpu.iterator()).toIterable().extracting("range").containsExactly(ContentRange.fromString("4194304-8388607"));
 
       assertEquals(server.takeRequest().getRequestLine(),
               "GET /-/vaults/examplevault/multipart-uploads/" + MULTIPART_UPLOAD_ID + "?limit=1&marker=1001 " + HTTP);

--- a/project/pom.xml
+++ b/project/pom.xml
@@ -245,7 +245,7 @@
     <!-- Test dependency versions -->
     <testng.version>6.8.21</testng.version>
     <xmlunit.version>1.3</xmlunit.version>
-    <assertj-core.version>1.7.0</assertj-core.version>
+    <assertj-core.version>3.23.1</assertj-core.version>
     <assertj-guava.version>1.3.0</assertj-guava.version>
 
     <!-- Mock dependency versions -->


### PR DESCRIPTION
Enabled by requiring Java 8.  Also fix some minor API breakage.