### PR TITLE
JCLOUDS-1617: Fix HTTPS support in OkHttpCommandExecutorService

### DIFF
--- a/core/src/main/java/org/jclouds/Constants.java
+++ b/core/src/main/java/org/jclouds/Constants.java
@@ -375,6 +375,14 @@ public final class Constants {
     * Default value: 2 minutes.
     */
    public static final String PROPERTY_MAX_RATE_LIMIT_WAIT = "jclouds.max-ratelimit-wait";
+   
+   /**
+    * Boolean property.
+    * <p/>
+    * When true, the proxy server type is HTTPS i.e HTTP and SSL
+    * 
+    */
+   public static final String PROPERTY_PROXY_ENABLE_SSL_PROXY = "jclouds.enable-ssl-proxy";
 
    private Constants() {
       throw new AssertionError("intentionally unimplemented");

--- a/core/src/main/java/org/jclouds/proxy/internal/GuiceProxyConfig.java
+++ b/core/src/main/java/org/jclouds/proxy/internal/GuiceProxyConfig.java
@@ -24,6 +24,7 @@ import static org.jclouds.Constants.PROPERTY_PROXY_PORT;
 import static org.jclouds.Constants.PROPERTY_PROXY_SYSTEM;
 import static org.jclouds.Constants.PROPERTY_PROXY_TYPE;
 import static org.jclouds.Constants.PROPERTY_PROXY_USER;
+import static org.jclouds.Constants.PROPERTY_PROXY_ENABLE_SSL_PROXY;
 
 import java.net.Proxy;
 import java.net.Proxy.Type;
@@ -69,6 +70,9 @@ public class GuiceProxyConfig implements ProxyConfig {
    @Inject(optional = true)
    @Named(PROPERTY_PROXY_TYPE)
    private Proxy.Type type = Proxy.Type.HTTP;
+   @Inject(optional = true)
+   @Named(PROPERTY_PROXY_ENABLE_SSL_PROXY)
+   private Boolean sslProxyEnabled = false;
 
    @Override
    public Optional<HostAndPort> getProxy() {
@@ -116,6 +120,10 @@ public class GuiceProxyConfig implements ProxyConfig {
    @Override
    public boolean isJvmProxyEnabled() {
       return jvmProxyEnabled;
+   }
+   
+   public boolean isSslProxyEnabled() {
+      return sslProxyEnabled;
    }
 
    /**

--- a/drivers/okhttp/src/main/java/org/jclouds/http/okhttp/DelegatingSocketFactory.java
+++ b/drivers/okhttp/src/main/java/org/jclouds/http/okhttp/DelegatingSocketFactory.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.http.okhttp;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+
+import javax.net.SocketFactory;
+
+public class DelegatingSocketFactory extends SocketFactory {
+	private final SocketFactory delegate;
+
+	public DelegatingSocketFactory(SocketFactory delegate) {
+		this.delegate = delegate;
+	}
+
+	@Override
+	public Socket createSocket() throws IOException {
+		Socket socket = delegate.createSocket();
+		return configureSocket(socket);
+	}
+
+	@Override
+	public Socket createSocket(String host, int port) throws IOException {
+		Socket socket = delegate.createSocket(host, port);
+		return configureSocket(socket);
+	}
+
+	@Override
+	public Socket createSocket(String host, int port, InetAddress localAddress, int localPort) throws IOException {
+		Socket socket = delegate.createSocket(host, port, localAddress, localPort);
+		return configureSocket(socket);
+	}
+
+	@Override
+	public Socket createSocket(InetAddress host, int port) throws IOException {
+		Socket socket = delegate.createSocket(host, port);
+		return configureSocket(socket);
+	}
+
+	@Override
+	public Socket createSocket(InetAddress host, int port, InetAddress localAddress, int localPort) throws IOException {
+		Socket socket = delegate.createSocket(host, port, localAddress, localPort);
+		return configureSocket(socket);
+	}
+
+	protected Socket configureSocket(Socket socket) throws IOException {
+		// No-op by default.
+		return socket;
+	}
+}

--- a/drivers/okhttp/src/main/java/org/jclouds/http/okhttp/DelegatingSocketFactory.java
+++ b/drivers/okhttp/src/main/java/org/jclouds/http/okhttp/DelegatingSocketFactory.java
@@ -22,6 +22,21 @@ import java.net.Socket;
 
 import javax.net.SocketFactory;
 
+/**
+ * The {@code DelegatingSocketFactory} class delegates instance of
+ * SSLSocketFactory to SocketFactory.
+ * 
+ * <p>
+ * Note:
+ * {@link okhttp3.OkHttpClient.Builder#sslSocketFactory(javax.net.ssl.SSLSocketFactory)}
+ * method deprecated.
+ * 
+ * <p>
+ * Note: {@link okhttp3.OkHttpClient.Builder#socketFactory(SocketFactory)}
+ * method doesn't accept {@code javax.net.ssl.SSLSocketFactory.getDefault()} at
+ * runtime, throws {@code java.lang.IllegalArgumentException}.
+ * 
+ */
 public class DelegatingSocketFactory extends SocketFactory {
 	private final SocketFactory delegate;
 

--- a/drivers/okhttp/src/main/java/org/jclouds/http/okhttp/OkHttpCommandExecutorService.java
+++ b/drivers/okhttp/src/main/java/org/jclouds/http/okhttp/OkHttpCommandExecutorService.java
@@ -31,6 +31,7 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 import javax.inject.Named;
+import javax.net.ssl.SSLSocketFactory;
 
 import okhttp3.Authenticator;
 import okhttp3.Credentials;
@@ -196,6 +197,10 @@ public final class OkHttpCommandExecutorService extends BaseHttpCommandExecutorS
 				}
 			};
 			okHttpClientBuilder.proxyAuthenticator(proxyAuthenticator);
+		}
+		
+		if (proxyConfig.isSslProxyEnabled()) {
+			okHttpClientBuilder.socketFactory(new DelegatingSocketFactory(SSLSocketFactory.getDefault()));
 		}
 	  OkHttpClient requestScopedClient = okHttpClientBuilder.build();
 	  


### PR DESCRIPTION
Added support for  proxy server type = HTTPS