### PR TITLE
Check state of a deprecated image for null

### DIFF
--- a/providers/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/functions/GoogleComputeEngineImageToImage.java
+++ b/providers/google-compute-engine/src/main/java/org/jclouds/googlecomputeengine/compute/functions/GoogleComputeEngineImageToImage.java
@@ -44,7 +44,7 @@ public final class GoogleComputeEngineImageToImage implements Function<Image, or
               .status(Status.AVAILABLE)
               .uri(image.selfLink());
 
-      if (image.deprecated() != null) {
+      if (image.deprecated() != null && image.deprecated().state() != null) {
          builder.userMetadata(ImmutableMap.of("deprecatedState", image.deprecated().state().name()));
          if (image.deprecated().state() == State.DELETED){
             builder.status(Status.DELETED);

--- a/providers/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/compute/functions/GoogleComputeEngineImageToImageTest.java
+++ b/providers/google-compute-engine/src/test/java/org/jclouds/googlecomputeengine/compute/functions/GoogleComputeEngineImageToImageTest.java
@@ -85,6 +85,19 @@ public class GoogleComputeEngineImageToImageTest {
       assertEquals(transformed.getStatus(), Status.AVAILABLE);
    }
 
+   public void testDeprecatedAndNullState(){
+      GoogleComputeEngineImageToImage imageToImage = new GoogleComputeEngineImageToImage(new ImageNameToOperatingSystem());
+      Deprecated deprecated =  Deprecated.create(
+              null, // state
+              URI.create("http://baseurl/projects/centos-cloud/global/images/centos-6-2-v20120326test"), // replacement
+              "2014-07-16T22:16:13.468Z", // deprecated
+              "2015-07-16T22:16:13.468Z", // obsolete
+              "2016-07-16T22:16:13.468Z"); // deleted
+      Image image = image("test-deprecated", deprecated);
+      org.jclouds.compute.domain.Image transformed = imageToImage.apply(image);
+      assertEquals(transformed.getStatus(), Status.AVAILABLE);
+   }
+
    private static Image image(String name, Deprecated deprecated) {
       return Image.create( //
             "1234", // id


### PR DESCRIPTION
There is something about `debian-10-buster-v20221206` image on GCE that causes NPE in `GoogleComputeEngineImageToImage#apply`.

Signed-off-by: Mykola Mandra <algairim@gmail.com>