### PR TITLE
Replace TravisCI with GitHub Actions

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+github:
+  description: The Java Multi-Cloud Toolkit
+  homepage: https://jclouds.apache.org/
+  labels:
+    - java
+    - library
+    - cloud
+    - jclouds
+
+  # Uncomment the following lines if at some point we feel like
+  # we want to control merges and pull request builds.
+  #
+  # enabled_merge_buttons:
+  #   squash:  true
+  #   merge:   false
+  #   rebase:  false
+  # protected_branches:
+  #   master:
+  #     required_status_checks:
+  #       contexts:
+  #         - build
+  #     required_pull_request_reviews:
+  #       required_approving_review_count: 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,20 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-language: java
+name: CI
 
-env:
-  - LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
-jdk:
-  - openjdk8
-
-sudo: false
-install: skip
-
-cache:
-  directories:
-    - $HOME/.m2
-
-script: mvn clean verify checkstyle:checkstyle -B -q -Dorg.slf4j.simpleLogger.defaultLogLevel=ERROR -Pdoc,src
-
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          java-version: "8"
+          distribution: temurin
+          cache: maven
+      - name: Build
+        run: mvn clean verify checkstyle:checkstyle -B -q -Dorg.slf4j.simpleLogger.defaultLogLevel=ERROR -Pdoc,src


### PR DESCRIPTION
TravisCI is not allowed anymore for ASF projects. This PR moves our CI/PR build to GHA.