### PR TITLE
Upgrade to EasyMock 5.1.0

### DIFF
--- a/project/pom.xml
+++ b/project/pom.xml
@@ -249,9 +249,6 @@
     <assertj-core.version>3.23.1</assertj-core.version>
     <assertj-guava.version>1.3.0</assertj-guava.version>
 
-    <!-- Mock dependency versions -->
-    <easymock.version>4.3</easymock.version>
-
     <!-- Static analysis dependency versions -->
     <jsr305.version>1.3.9</jsr305.version>
 
@@ -396,7 +393,7 @@
       <dependency>
         <groupId>org.easymock</groupId>
         <artifactId>easymock</artifactId>
-        <version>${easymock.version}</version>
+        <version>5.1.0</version>
       </dependency>
       <dependency>
         <groupId>com.squareup.okhttp3</groupId>


### PR DESCRIPTION
This resolves a Java 17 compatibility issue.  Release notes:

https://github.com/easymock/easymock/releases/tag/easymock-5.0.0
https://github.com/easymock/easymock/releases/tag/easymock-5.0.1
https://github.com/easymock/easymock/releases/tag/easymock-5.1.0