### PR TITLE
JCLOUDS-1618: Upgrade to gson 2.10.1

### DIFF
--- a/core/src/main/java/org/jclouds/json/config/GsonModule.java
+++ b/core/src/main/java/org/jclouds/json/config/GsonModule.java
@@ -38,6 +38,7 @@ import org.jclouds.domain.JsonBall;
 import org.jclouds.domain.LoginCredentials;
 import org.jclouds.json.Json;
 import org.jclouds.json.SerializedNames;
+import com.google.gson.ReflectionAccessFilter;
 import com.google.gson.internal.ConstructorConstructor;
 import com.google.gson.internal.Excluder;
 import com.google.gson.internal.JsonReaderInternalAccess;
@@ -61,6 +62,7 @@ import org.jclouds.json.internal.NullFilteringTypeAdapterFactories.SetTypeAdapte
 import org.jclouds.json.internal.NullHackJsonLiteralAdapter;
 import org.jclouds.json.internal.OptionalTypeAdapterFactory;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
 import com.google.common.collect.ImmutableSet;
@@ -131,7 +133,7 @@ public class GsonModule extends AbstractModule {
             ImmutableSet.of(new ExtractNamed()));
 
       builder.registerTypeAdapterFactory(new DeserializationConstructorAndReflectiveTypeAdapterFactory(
-            new ConstructorConstructor(ImmutableMap.<Type, InstanceCreator<?>>of()), serializationPolicy,
+            new ConstructorConstructor(ImmutableMap.<Type, InstanceCreator<?>>of(), /*useJdkUnsafe=*/ false, ImmutableList.<ReflectionAccessFilter>of()), serializationPolicy,
             Excluder.DEFAULT, deserializationPolicy));
 
       // complicated (serializers/deserializers as they need context to operate)

--- a/core/src/main/java/org/jclouds/json/internal/DeserializationConstructorAndReflectiveTypeAdapterFactory.java
+++ b/core/src/main/java/org/jclouds/json/internal/DeserializationConstructorAndReflectiveTypeAdapterFactory.java
@@ -26,6 +26,7 @@ import java.lang.reflect.Modifier;
 import java.util.List;
 import java.util.Map;
 
+import com.google.gson.ReflectionAccessFilter;
 import com.google.gson.internal.bind.JsonAdapterAnnotationTypeAdapterFactory;
 import com.google.gson.internal.ConstructorConstructor;
 import com.google.gson.internal.Excluder;
@@ -35,6 +36,7 @@ import org.jclouds.json.internal.NamingStrategies.AnnotationConstructorNamingStr
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
 import com.google.common.reflect.Invokable;
@@ -117,7 +119,7 @@ public final class DeserializationConstructorAndReflectiveTypeAdapterFactory imp
             "deserializationFieldNamingPolicy");
       this.delegateFactory = new ReflectiveTypeAdapterFactory(constructorConstructor, checkNotNull(
             serializationFieldNamingPolicy, "fieldNamingPolicy"), checkNotNull(excluder, "excluder"),
-              new JsonAdapterAnnotationTypeAdapterFactory(constructorConstructor));
+              new JsonAdapterAnnotationTypeAdapterFactory(constructorConstructor), ImmutableList.<ReflectionAccessFilter>of());
    }
 
    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {

--- a/core/src/test/java/org/jclouds/json/internal/DeserializationConstructorAndReflectiveTypeAdapterFactoryTest.java
+++ b/core/src/test/java/org/jclouds/json/internal/DeserializationConstructorAndReflectiveTypeAdapterFactoryTest.java
@@ -31,6 +31,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.jclouds.json.SerializedNames;
+import com.google.gson.ReflectionAccessFilter;
 import com.google.gson.internal.ConstructorConstructor;
 import com.google.gson.internal.Excluder;
 import org.jclouds.json.internal.NamingStrategies.AnnotationConstructorNamingStrategy;
@@ -41,6 +42,7 @@ import org.testng.annotations.Test;
 
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
@@ -67,7 +69,8 @@ public final class DeserializationConstructorAndReflectiveTypeAdapterFactoryTest
             ImmutableSet.of(ConstructorProperties.class, SerializedNames.class, Inject.class),
             ImmutableSet.of(new ExtractNamed()));
 
-      return new DeserializationConstructorAndReflectiveTypeAdapterFactory(new ConstructorConstructor(ImmutableMap.<Type, InstanceCreator<?>>of()),
+      return new DeserializationConstructorAndReflectiveTypeAdapterFactory(
+            new ConstructorConstructor(ImmutableMap.<Type, InstanceCreator<?>>of(), /*useJdkUnsafe=*/ false, ImmutableList.<ReflectionAccessFilter>of()),
             serializationPolicy, Excluder.DEFAULT, deserializationPolicy);
    }
 

--- a/project/pom.xml
+++ b/project/pom.xml
@@ -221,7 +221,7 @@
     <maven-surefire-plugin.version>3.1.0</maven-surefire-plugin.version>
 
     <!-- General dependency versions -->
-    <gson.version>2.8.9</gson.version>
+    <gson.version>2.10.1</gson.version>
     <guava.version>32.0.0-jre</guava.version>
     <guice.version>5.1.0</guice.version>
 


### PR DESCRIPTION
~~This also upgrades bnd to 7.0.0-SNAPSHOT to work around a `META-INF/versions/9/module-info.class=module-info` issue.  Obviously we cannot merge this due to the use of a SNAPSHOT version but maybe someone has a better suggestion how to approach this?~~

Removed bnd in #177.