### PR TITLE
check file exists in getContainerAccess

### DIFF
--- a/apis/filesystem/src/main/java/org/jclouds/filesystem/strategy/internal/FilesystemStorageStrategyImpl.java
+++ b/apis/filesystem/src/main/java/org/jclouds/filesystem/strategy/internal/FilesystemStorageStrategyImpl.java
@@ -187,7 +187,11 @@ public class FilesystemStorageStrategyImpl implements LocalStorageStrategy {
 
    @Override
    public ContainerAccess getContainerAccess(String container) {
-      Path path = new File(buildPathStartingFromBaseDir(container)).toPath();
+      File file = new File(buildPathStartingFromBaseDir(container));
+      if (!file.exists()) {
+         throw new ContainerNotFoundException(container, "in getContainerAccess");
+      }
+      Path path = file.toPath();
 
       if ( isWindows() ) {
          try {


### PR DESCRIPTION
I found that getBlobAccess checks file exists, but getContainerAccess doesn't check. This causes s3proxy throws exceptions when OPTIONS a non-exist bucket. https://github.com/gaul/s3proxy/pull/561