### PR TITLE
do not remove md in DelimeterFilter then add it by commonPrefixes; just keep it

### DIFF
--- a/blobstore/src/main/java/org/jclouds/blobstore/config/LocalBlobStore.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/config/LocalBlobStore.java
@@ -364,6 +364,9 @@ public final class LocalBlobStore implements BlobStore {
             o = prefix + o;
          }
          md.setName(o + delimiter);
+         if (!contents.contains(md)) {
+            contents.add(md);
+         }
          contents.add(md);
       }
       return contents;
@@ -471,7 +474,7 @@ public final class LocalBlobStore implements BlobStore {
       public boolean apply(StorageMetadata metadata) {
          String name = metadata.getName();
          if (prefix == null || prefix.isEmpty()) {
-            return name.indexOf(delimiter) == -1;
+            return name.indexOf(delimiter) == -1 || name.indexOf(delimiter) == name.length() - delimiter.length();
          }
          if (name.startsWith(prefix)) {
             String unprefixedName = name.substring(prefix.length());
@@ -479,7 +482,7 @@ public final class LocalBlobStore implements BlobStore {
                // a blob that matches the prefix should also be returned
                return true;
             }
-            return unprefixedName.indexOf(delimiter) == -1;
+            return unprefixedName.indexOf(delimiter) == -1 || unprefixedName.indexOf(delimiter) == unprefixedName.length() - delimiter.length();
          }
          return false;
       }
@@ -505,7 +508,7 @@ public final class LocalBlobStore implements BlobStore {
             }
          }
          if (working.indexOf(delimiter) >= 0) {
-            // include the delimiter in the result
+            // not include the delimiter in the result
             return working.substring(0, working.indexOf(delimiter));
          } else {
             return NO_PREFIX;

--- a/blobstore/src/main/java/org/jclouds/blobstore/config/LocalBlobStore.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/config/LocalBlobStore.java
@@ -367,7 +367,6 @@ public final class LocalBlobStore implements BlobStore {
          if (!contents.contains(md)) {
             contents.add(md);
          }
-         contents.add(md);
       }
       return contents;
    }

--- a/blobstore/src/main/java/org/jclouds/blobstore/config/LocalBlobStore.java
+++ b/blobstore/src/main/java/org/jclouds/blobstore/config/LocalBlobStore.java
@@ -364,9 +364,7 @@ public final class LocalBlobStore implements BlobStore {
             o = prefix + o;
          }
          md.setName(o + delimiter);
-         if (!contents.contains(md)) {
-            contents.add(md);
-         }
+         contents.add(md);
       }
       return contents;
    }

--- a/blobstore/src/test/java/org/jclouds/blobstore/strategy/internal/ListContainerTest.java
+++ b/blobstore/src/test/java/org/jclouds/blobstore/strategy/internal/ListContainerTest.java
@@ -193,6 +193,22 @@ public class ListContainerTest {
       assertThat(Iterables.get(results, 0).getType()).isNotEqualTo(StorageType.RELATIVE_PATH);
    }
 
+   public void testListBlobEndsWithDelimiterAndDelimiterFilter() {
+      String containerName = "testListBlobEndsWithDelimiterAndDelimiterFilter";
+      blobStore.createContainerInLocation(null, containerName);
+      blobStore.putBlob(containerName, blobStore.blobBuilder("foo/").type(StorageType.FOLDER)
+         .payload(ByteSource.empty()).build());
+      blobStore.putBlob(containerName, blobStore.blobBuilder("bar/text").type(StorageType.BLOB)
+         .payload(ByteSource.empty()).build());
+      PageSet<? extends StorageMetadata> results = blobStore.list(containerName,
+         ListContainerOptions.Builder.delimiter("/"));
+      assertThat(results.size()).isEqualTo(2);
+      assertThat(Iterables.get(results, 0).getName()).isEqualTo("bar/");
+      assertThat(Iterables.get(results, 0).getType()).isEqualTo(StorageType.RELATIVE_PATH);
+      assertThat(Iterables.get(results, 1).getName()).isEqualTo("foo/");
+      assertThat(Iterables.get(results, 1).getType()).isEqualTo(StorageType.FOLDER);
+   }
+
    public void testDirectoryListing() {
       String containerName = "testDirectoryListing";
       blobStore.createContainerInLocation(null, containerName);


### PR DESCRIPTION
If the metadata ends with delimiter, it is removed in `DelimterFilter.apply`, then add it back by loop `commonPrefixes`. But many information in the metadata lost, such as lastModified time. My solution is keeping them in the DelimeterFilter.