### PR TITLE
Upgrade to Netty 4.1.107

### DIFF
--- a/drivers/netty/pom.xml
+++ b/drivers/netty/pom.xml
@@ -45,8 +45,8 @@
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
-      <artifactId>netty</artifactId>
-      <version>3.10.6.Final</version>
+      <artifactId>netty-all</artifactId>
+      <version>4.1.107.Final</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This resolves several security issues with versions earlier than 4.0.0.