### PR TITLE
Modify S3 endpoint regex pattern to support VPC endpoints.

### DIFF
--- a/apis/s3/src/main/java/org/jclouds/s3/filters/AwsHostNameUtils.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/filters/AwsHostNameUtils.java
@@ -26,7 +26,7 @@ import java.util.regex.Pattern;
 
 public class AwsHostNameUtils {
 
-   private static final Pattern S3_ENDPOINT_PATTERN = Pattern.compile("^(?:.+\\.)?s3[.-]([a-z0-9-]+)$");
+   private static final Pattern S3_ENDPOINT_PATTERN = Pattern.compile("^(?:.+\\.)?s3[.\\-]([a-z0-9-]+)(?>\\.[a-z0-9-]+)*$");
 
    private static final Pattern STANDARD_CLOUDSEARCH_ENDPOINT_PATTERN = Pattern.compile("^(?:.+\\.)?([a-z0-9-]+)\\.cloudsearch$");
 
@@ -107,7 +107,7 @@ public class AwsHostNameUtils {
 
       Matcher matcher = S3_ENDPOINT_PATTERN.matcher(fragment);
       if (matcher.matches()) {
-         // host was 'bucket.s3-[region].amazonaws.com'.
+         // host was '[whatever].s3[.|-]-[region].[whatever].amazonaws.com
          return matcher.group(1);
       }
 

--- a/apis/s3/src/test/java/org/jclouds/s3/filters/AwsHostNameUtilsTest.java
+++ b/apis/s3/src/test/java/org/jclouds/s3/filters/AwsHostNameUtilsTest.java
@@ -52,9 +52,19 @@ public class AwsHostNameUtilsTest {
          "s3"
       );
 
-
       Assert.assertEquals(
          AwsHostNameUtils.parseServiceName(URI.create("https://test-bucket.s3.cn-north-1.amazonaws.com.cn")),
+         "s3"
+      );
+   }
+
+   @Test
+   // test s3 virtual private cloud URL
+   public void testVpcUrl() {
+      Assert.assertEquals(
+         AwsHostNameUtils.parseServiceName(
+              URI.create("https://bucket.vpce-0037af66cf9b0cc5e-zop31d9j.s3.us-east-1.vpce.amazonaws.com")
+         ),
          "s3"
       );
    }


### PR DESCRIPTION
Virtual private clouds are a relatively new feature of AWS. The jclouds AWS endpoint regex was not originally designed to be able to handle VPC formatted endpoints. This new expanded regex does the trick. The change also (incidentally) allows the regex to recognize both forms of basic s3 endpoints: s3-region and s3.region.