### PR TITLE
Fix ContextBuilder bug when using credentials supplier with azureblob

### DIFF
--- a/core/src/main/java/org/jclouds/ContextBuilder.java
+++ b/core/src/main/java/org/jclouds/ContextBuilder.java
@@ -74,6 +74,7 @@ import org.jclouds.providers.Providers;
 import org.jclouds.providers.config.BindProviderMetadataContextAndCredentials;
 import org.jclouds.providers.internal.UpdateProviderMetadataFromProperties;
 import org.jclouds.reflect.Invocation;
+import org.jclouds.rest.ApiContext;
 import org.jclouds.rest.ConfiguresCredentialStore;
 import org.jclouds.rest.ConfiguresHttpApi;
 import org.jclouds.rest.HttpApiMetadata;
@@ -364,10 +365,16 @@ public class ContextBuilder {
       defaults.setProperty(PROPERTY_API, apiMetadata.getName());
       defaults.setProperty(PROPERTY_API_VERSION, apiVersion);
       defaults.setProperty(PROPERTY_BUILD_VERSION, buildVersion);
-      if (identity.isPresent())
-         defaults.setProperty(PROPERTY_IDENTITY, identity.get());
-      if (credential != null)
-         defaults.setProperty(PROPERTY_CREDENTIAL, credential);
+      if (credentialsSupplierOption.isPresent()) {
+         Credentials credentials = credentialsSupplierOption.get().get();
+         defaults.setProperty(PROPERTY_IDENTITY, credentials.identity);
+         defaults.setProperty(PROPERTY_CREDENTIAL, credentials.credential);
+      } else {
+         if (identity.isPresent())
+            defaults.setProperty(PROPERTY_IDENTITY, identity.get());
+         if (credential != null)
+            defaults.setProperty(PROPERTY_CREDENTIAL, credential);
+      }
       if (overrides.isPresent())
          putAllAsString(overrides.get(), defaults);
       putAllAsString(propertiesPrefixedWithJcloudsApiOrProviderId(getSystemProperties(), apiMetadata.getId(), providerId), defaults);


### PR DESCRIPTION
Azure cloud providers specifically use an identity as part of their endpoint. 

When attempting to use a ContextBuilder with the (new-ish?) credentialsSupplier option, we were seeing errors building an endpoint due to string interpolation failures, since the Azure module was not expecting a Supplier<Credentials> (rather, a specific `identity` and `credential`)

This is not a comprehensive fix (any subsequent change to the identity will not be reflected in the endpoint going forward) but partially addresses a serious problem (unable to use ContextBuilder's `credentialsSupplier` for Azure providers)

I plan on a more thorough change that will allow on-the-fly changes to an Azure provider's identity/credential, but this is more difficult. I believe I'll need to find every place where the endpoint is referenced and handle the case where a credentialsSupplier is being used (IOW, every place where the endpoint must be generated on the fly). 

Any pointers or feedback about the above is appreciated!