### PR TITLE
Fixes issue with AzureBlobStore blockid incorrectly using base64url encoding

### DIFF
--- a/providers/azureblob/src/main/java/org/jclouds/azureblob/blobstore/AzureBlobStore.java
+++ b/providers/azureblob/src/main/java/org/jclouds/azureblob/blobstore/AzureBlobStore.java
@@ -440,9 +440,10 @@ public class AzureBlobStore extends BaseBlobStore {
       return sync.putBlockList(mpu.containerName(), azureBlob, blocks.build());
    }
 
-   static String makeBlockId(int partNumber) {
-       return BaseEncoding.base64Url().encode(Ints.toByteArray(partNumber));
-   }
+  static String makeBlockId(int partNumber) {
+      // Azure expects a base64-encoded string ONLY. It does not support base64url encoding. 
+     return BaseEncoding.base64().encode(Ints.toByteArray(partNumber));
+  }
    
    @Override
    public MultipartPart uploadMultipartPart(MultipartUpload mpu, int partNumber, Payload payload) {

--- a/providers/azureblob/src/test/java/org/jclouds/azureblob/blobstore/AzureBlobStoreTest.java
+++ b/providers/azureblob/src/test/java/org/jclouds/azureblob/blobstore/AzureBlobStoreTest.java
@@ -28,7 +28,7 @@ import java.util.regex.Pattern;
 @Test(groups = "unit", testName = "AzureBlobStore")
 public class AzureBlobStoreTest {
     
-    private static final Pattern VALIDATION_PATTERN = Pattern.compile("[a-zA-Z0-9\\-_=]*");
+    private static final Pattern VALIDATION_PATTERN = Pattern.compile("^[a-zA-Z0-9+/=]*$");
 
     public void testMakeBlockId() {
        // how can i achieve something like a junit5 parametrized test in testng?


### PR DESCRIPTION
Despite [JCLOUDS-1615](https://issues.apache.org/jira/browse/JCLOUDS-1615), using base64url encoded values is not supported by the [Put Block](https://learn.microsoft.com/en-us/rest/api/storageservices/put-block) endpoint.

When attempting to query this endpoint with `partNumber` set to `248` (which is `blockid: AAAA-A==`) I received this error:

```xml
<?xml version="1.0" encoding="utf-8"?><Error><Code>InvalidQueryParameterValue</Code><Message>Value for one of the query parameters specified in the request URI is invalid.
RequestId:632a8422-501e-006c-3db4-e238fb000000
Time:2024-07-30T19:10:34.4638223Z</Message><QueryParameterName>blockid</QueryParameterName><QueryParameterValue>AAAA-A==</QueryParameterValue><Reason>Not a valid base64 string.</Reason></Error>
```

I have confirmed directly with Microsoft that the correct value here is a standard base64 string that is url encoded, which should not be confused with base64url encoding which is NOT supported.

As far as the original ticket ([JCLOUDS-1615](https://issues.apache.org/jira/browse/JCLOUDS-1615)) which mentions an error related to  `+` reporting as not a valid base64 string, I have tried to replicate the issue and I am unable to do so. My guess is that this was a bug that existed on Microsoft's side and they have since fixed it. Either way, from their own words, it should be a base64 string. `+` and `/` are supported.