### PR TITLE
Fix digitalocean2 NumberFormatException

### DIFF
--- a/providers/digitalocean2/src/main/java/org/jclouds/digitalocean2/compute/config/DigitalOcean2ComputeServiceContextModule.java
+++ b/providers/digitalocean2/src/main/java/org/jclouds/digitalocean2/compute/config/DigitalOcean2ComputeServiceContextModule.java
@@ -123,7 +123,7 @@ public class DigitalOcean2ComputeServiceContextModule extends
 
    @Provides
    @Named(TIMEOUT_IMAGE_AVAILABLE)
-   protected Predicate<Integer> provideImageAvailablePredicate(final DigitalOcean2Api api, Timeouts timeouts,
+   protected Predicate<Long> provideImageAvailablePredicate(final DigitalOcean2Api api, Timeouts timeouts,
          PollPeriod pollPeriod) {
       return retry(new ActionDonePredicate(api), timeouts.imageAvailable, pollPeriod.pollInitialPeriod,
             pollPeriod.pollMaxPeriod);
@@ -138,14 +138,14 @@ public class DigitalOcean2ComputeServiceContextModule extends
    }
 
    @Provides
-   protected Predicate<Integer> provideActionCompletedPredicate(final DigitalOcean2Api api, Timeouts timeouts,
+   protected Predicate<Long> provideActionCompletedPredicate(final DigitalOcean2Api api, Timeouts timeouts,
          PollPeriod pollPeriod) {
       return retry(new ActionDonePredicate(api), timeouts.imageAvailable, pollPeriod.pollInitialPeriod,
             pollPeriod.pollMaxPeriod);
    }
 
    @VisibleForTesting
-   static class ActionDonePredicate implements Predicate<Integer> {
+   static class ActionDonePredicate implements Predicate<Long> {
 
       private final DigitalOcean2Api api;
 
@@ -154,7 +154,7 @@ public class DigitalOcean2ComputeServiceContextModule extends
       }
 
       @Override
-      public boolean apply(Integer input) {
+      public boolean apply(Long input) {
          checkNotNull(input, "action id cannot be null");
          Action current = api.actionApi().get(input);
          switch (current.status()) {

--- a/providers/digitalocean2/src/main/java/org/jclouds/digitalocean2/compute/extensions/DigitalOcean2ImageExtension.java
+++ b/providers/digitalocean2/src/main/java/org/jclouds/digitalocean2/compute/extensions/DigitalOcean2ImageExtension.java
@@ -60,13 +60,13 @@ public class DigitalOcean2ImageExtension implements ImageExtension {
    protected Logger logger = Logger.NULL;
 
    private final DigitalOcean2Api api;
-   private final Predicate<Integer> imageAvailablePredicate;
+   private final Predicate<Long> imageAvailablePredicate;
    private final Predicate<Integer> nodeRunningPredicate;
    private final Function<ImageInRegion, Image> imageTransformer;
    private final ListeningExecutorService userExecutor;
 
    @Inject DigitalOcean2ImageExtension(DigitalOcean2Api api,
-         @Named(TIMEOUT_IMAGE_AVAILABLE) Predicate<Integer> imageAvailablePredicate,
+         @Named(TIMEOUT_IMAGE_AVAILABLE) Predicate<Long> imageAvailablePredicate,
          @Named(TIMEOUT_NODE_RUNNING) Predicate<Integer> nodeRunningPredicate,
          Function<ImageInRegion, Image> imageTransformer,
          @Named(Constants.PROPERTY_USER_THREADS) ListeningExecutorService userExecutor) {

--- a/providers/digitalocean2/src/main/java/org/jclouds/digitalocean2/domain/Action.java
+++ b/providers/digitalocean2/src/main/java/org/jclouds/digitalocean2/domain/Action.java
@@ -49,7 +49,7 @@ public abstract class Action {
       }
    }
 
-   public abstract int id();
+   public abstract long id();
    public abstract Status status();
    public abstract String type();
    public abstract Date startedAt();
@@ -61,7 +61,7 @@ public abstract class Action {
 
    @SerializedNames({ "id", "status", "type", "started_at", "completed_at", "resource_id", "resource_type",
       "region", "region_slug" })
-   public static Action create(int id, Status status, String type, Date startedAt, Date completedAt, long resourceId,
+   public static Action create(long id, Status status, String type, Date startedAt, Date completedAt, long resourceId,
          String resourceType, Region region, String regionSlug) {
       return new AutoValue_Action(id, status, type, startedAt, completedAt, resourceId, resourceType, region,
             regionSlug);

--- a/providers/digitalocean2/src/main/java/org/jclouds/digitalocean2/domain/DropletCreate.java
+++ b/providers/digitalocean2/src/main/java/org/jclouds/digitalocean2/domain/DropletCreate.java
@@ -35,12 +35,12 @@ public abstract class DropletCreate {
       
       @AutoValue
       public abstract static class ActionLink {
-         public abstract int id();
+         public abstract long id();
          public abstract String rel();
          public abstract URI href();
          
          @SerializedNames({"id", "rel", "href"})
-         public static ActionLink create(int id, String rel, URI href) {
+         public static ActionLink create(long id, String rel, URI href) {
             return new AutoValue_DropletCreate_Links_ActionLink(id, rel, href);
          }
          

--- a/providers/digitalocean2/src/main/java/org/jclouds/digitalocean2/features/ActionApi.java
+++ b/providers/digitalocean2/src/main/java/org/jclouds/digitalocean2/features/ActionApi.java
@@ -107,7 +107,7 @@ public interface ActionApi extends Closeable {
    @Path("/{id}")
    @Fallback(NullOnNotFoundOr404.class)
    @Nullable
-   Action get(@PathParam("id") int id);
+   Action get(@PathParam("id") long id);
    
 }
 

--- a/providers/digitalocean2/src/test/java/org/jclouds/digitalocean2/compute/config/ActionDonePredicateTest.java
+++ b/providers/digitalocean2/src/test/java/org/jclouds/digitalocean2/compute/config/ActionDonePredicateTest.java
@@ -46,8 +46,8 @@ public class ActionDonePredicateTest {
       replay(actionApi, api);
 
       ActionDonePredicate predicate = new ActionDonePredicate(api);
-      assertTrue(predicate.apply(1));
-      assertFalse(predicate.apply(2));
+      assertTrue(predicate.apply(1L));
+      assertFalse(predicate.apply(2L));
    }
 
    public void testActionStatusError() {
@@ -61,7 +61,7 @@ public class ActionDonePredicateTest {
       ActionDonePredicate predicate = new ActionDonePredicate(api);
 
       try {
-         predicate.apply(1);
+         predicate.apply(1L);
          fail("Method should have thrown an IllegalStateException");
       } catch (IllegalStateException ex) {
          assertEquals(ex.getMessage(), "Resource is in invalid status: ERRORED");

--- a/providers/digitalocean2/src/test/java/org/jclouds/digitalocean2/internal/BaseDigitalOcean2ApiLiveTest.java
+++ b/providers/digitalocean2/src/test/java/org/jclouds/digitalocean2/internal/BaseDigitalOcean2ApiLiveTest.java
@@ -45,7 +45,7 @@ import com.google.inject.name.Names;
 
 public class BaseDigitalOcean2ApiLiveTest extends BaseApiLiveTest<DigitalOcean2Api> {
 
-   private Predicate<Integer> actionCompleted;
+   private Predicate<Long> actionCompleted;
    private Predicate<Integer> nodeTerminated;
    private Predicate<Integer> nodeStopped;
    private Predicate<Integer> nodeRunning;
@@ -64,7 +64,7 @@ public class BaseDigitalOcean2ApiLiveTest extends BaseApiLiveTest<DigitalOcean2A
 
    @Override protected DigitalOcean2Api create(Properties props, Iterable<Module> modules) {
       Injector injector = newBuilder().modules(modules).overrides(props).buildInjector();
-      actionCompleted = injector.getInstance(Key.get(new TypeLiteral<Predicate<Integer>>(){}));
+      actionCompleted = injector.getInstance(Key.get(new TypeLiteral<Predicate<Long>>(){}));
       nodeTerminated = injector.getInstance(Key.get(new TypeLiteral<Predicate<Integer>>(){},
             Names.named(TIMEOUT_NODE_TERMINATED)));
       nodeStopped = injector.getInstance(Key.get(new TypeLiteral<Predicate<Integer>>(){},
@@ -79,7 +79,7 @@ public class BaseDigitalOcean2ApiLiveTest extends BaseApiLiveTest<DigitalOcean2A
             .build();
    }
 
-   protected void assertActionCompleted(int actionId) {
+   protected void assertActionCompleted(long actionId) {
       assertTrue(actionCompleted.apply(actionId), String.format("Action %s did not complete in the configured timeout", actionId));
    }
 

--- a/providers/digitalocean2/src/test/resources/droplet-create-res.json
+++ b/providers/digitalocean2/src/test/resources/droplet-create-res.json
@@ -26,9 +26,9 @@
     "links": {
         "actions": [
             {
-                "id": 35383956,
+                "id": 2512718872,
                 "rel": "create",
-                "href": "https://api.digitalocean.com/v2/actions/35383956"
+                "href": "https://api.digitalocean.com/v2/actions/2512718872"
             }
         ]
     }


### PR DESCRIPTION
 Changed org.jclouds.digitalocean2.domain.Action.id from int to long
 in order to fit large numbers sent in responses.

 This appears to be a misinterpretation of DigitalOceans ApiDocs,
 because in these docs, they fail to specify the size of their
 "integer" type. Therefore, I looked into their official GO Api
 sources at https://github.com/digitalocean/godo. There, they use
 the int type, which is platform dependant and usually has 64 bits.

 Therefore our digitalocean2 provider, should be refactored, changing
 **_all_** Ids from int/Integer to long/Long.

This PR is just the immediate fixup to make the jclouds (jenkins plugin)
work with current DigitalOcean again. The refactoring should be done
ASAP, otherwise we could run into similar problems, when the id values in
their API-resonses grow over time.
