### PR TITLE
Fix NPE on failure to parse AWSError when determing whether to retry request

### DIFF
--- a/apis/s3/src/main/java/org/jclouds/s3/handlers/S3RedirectionRetryHandler.java
+++ b/apis/s3/src/main/java/org/jclouds/s3/handlers/S3RedirectionRetryHandler.java
@@ -53,7 +53,7 @@ public class S3RedirectionRetryHandler extends RedirectionRetryHandler {
          command.incrementRedirectCount();
          closeClientButKeepContentStream(response);
          AWSError error = utils.parseAWSErrorFromContent(command.getCurrentRequest(), response);
-         String host = error.getDetails().get("Endpoint");
+         String host = error == null ? null : error.getDetails().get("Endpoint");
          if (host != null) {
             if (host.equals(command.getCurrentRequest().getEndpoint().getHost())) {
                // must be an amazon error related to


### PR DESCRIPTION
Under some conditions, attempting to parse an AWSError from a request (org.jclouds.aws.util.AWSUtils#parseAWSErrorFromContent) can wind up with a null result. 

S3RedirectionRetryHandler was not handling such null responses gracefully, and was instead hitting a NullPointerException. 

This one-line fix changes S3RedirectionRetryHandler to null-check results from the method mentioned above. 